### PR TITLE
fix: v0.2.2 — 9 bug fixes for correctness, UX, and performance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Git cache uses 60s TTL for "not available" state — avoids repeated subprocess timeouts when git is missing
 - Corrupt `settings.json` warning now mentions the `.bak` backup file
 - Narrow layout (<80 cols) drops `model` section to prevent line wrapping
+- Bar color threshold uses float precision — `85.5%` now correctly shows red, not yellow
+- Periodic cache cleanup removes files older than 2 days to prevent accumulation
 
 ## [0.2.1] - 2026-04-03
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.2] - 2026-04-03
+
+### Fixed
+- **Critical**: `_normalize()` no longer drops zero values — `0` for cost, tokens, duration, etc. is now correctly preserved instead of being treated as `None`
+- **Critical**: `--theme` help text now clarifies it's per-render only; directs users to `--install --theme` or `--setup` for persistence
+- Burn rate calculation now includes `cache_create` tokens — previously understated consumption
+- Bar color with compaction threshold uses raw context percentage — no more misleading red bar at 55% actual usage
+- Session count cache key includes date — prevents stale counts across midnight
+- Tool count cache TTL reduced from 30s to 10s — more responsive during active sessions
+- Git cache uses 60s TTL for "not available" state — avoids repeated subprocess timeouts when git is missing
+- Corrupt `settings.json` warning now mentions the `.bak` backup file
+- Narrow layout (<80 cols) drops `model` section to prevent line wrapping
+
 ## [0.2.1] - 2026-04-03
 
 ### Added

--- a/claude_statusline/__init__.py
+++ b/claude_statusline/__init__.py
@@ -1,3 +1,3 @@
 """claude-status: Beautiful status line for Claude Code."""
 
-__version__ = "0.2.1"
+__version__ = "0.2.2"

--- a/claude_statusline/bar.py
+++ b/claude_statusline/bar.py
@@ -34,7 +34,10 @@ def render_bar(pct, width=20, theme=None, compaction_threshold=None):
     if pct is None:
         return ""
 
-    # Scale relative to compaction threshold if configured
+    # Use raw percentage for color (reflects actual context fill)
+    color = _bar_color(max(0, min(100, int(pct))))
+
+    # Scale fill width relative to compaction threshold if configured
     if compaction_threshold and 0 < compaction_threshold <= 100:
         pct = (pct / compaction_threshold) * 100
 
@@ -53,7 +56,6 @@ def render_bar(pct, width=20, theme=None, compaction_threshold=None):
 
     filled = int(width * pct / 100)
     empty = width - filled
-    color = _bar_color(pct)
 
     bar_content = colors.colorize(
         filled_char * filled, color

--- a/claude_statusline/bar.py
+++ b/claude_statusline/bar.py
@@ -35,7 +35,7 @@ def render_bar(pct, width=20, theme=None, compaction_threshold=None):
         return ""
 
     # Use raw percentage for color (reflects actual context fill)
-    color = _bar_color(max(0, min(100, int(pct))))
+    color = _bar_color(max(0, min(100, float(pct))))
 
     # Scale fill width relative to compaction threshold if configured
     if compaction_threshold and 0 < compaction_threshold <= 100:

--- a/claude_statusline/cli.py
+++ b/claude_statusline/cli.py
@@ -43,6 +43,14 @@ def _settings_path():
     return os.path.join(home, ".claude", "settings.json")
 
 
+def _first(*vals):
+    """Return the first value that is not None."""
+    for v in vals:
+        if v is not None:
+            return v
+    return None
+
+
 def _normalize(data):
     """Normalize Claude Code JSON into a flat dict for rendering.
 
@@ -56,29 +64,29 @@ def _normalize(data):
     cu = cw.get("current_usage") or {}
     flat_usage = data.get("current_usage") or {}
 
-    out["used_percentage"] = cw.get("used_percentage") or flat_usage.get("used_percentage")
-    out["input_tokens"] = cu.get("input_tokens") or flat_usage.get("input_tokens")
-    out["output_tokens"] = cu.get("output_tokens") or flat_usage.get("output_tokens")
-    out["cache_read"] = (
-        cu.get("cache_read_input_tokens")
-        or flat_usage.get("cache_read_tokens")
+    out["used_percentage"] = _first(cw.get("used_percentage"), flat_usage.get("used_percentage"))
+    out["input_tokens"] = _first(cu.get("input_tokens"), flat_usage.get("input_tokens"))
+    out["output_tokens"] = _first(cu.get("output_tokens"), flat_usage.get("output_tokens"))
+    out["cache_read"] = _first(
+        cu.get("cache_read_input_tokens"),
+        flat_usage.get("cache_read_tokens"),
     )
-    out["cache_create"] = (
-        cu.get("cache_creation_input_tokens")
-        or flat_usage.get("cache_create_tokens")
+    out["cache_create"] = _first(
+        cu.get("cache_creation_input_tokens"),
+        flat_usage.get("cache_create_tokens"),
     )
-    out["context_size"] = (
-        cw.get("context_window_size")
-        or flat_usage.get("context_size")
+    out["context_size"] = _first(
+        cw.get("context_window_size"),
+        flat_usage.get("context_size"),
     )
 
     # Cost (nested or flat)
     cost_obj = data.get("cost") or {}
-    out["cost"] = cost_obj.get("total_cost_usd") or data.get("cost_usd")
-    out["duration"] = cost_obj.get("total_duration_ms") or data.get("session_duration_ms")
-    out["api_duration"] = cost_obj.get("total_api_duration_ms") or data.get("api_duration_ms")
-    out["lines_added"] = cost_obj.get("total_lines_added") or data.get("lines_added")
-    out["lines_removed"] = cost_obj.get("total_lines_removed") or data.get("lines_removed")
+    out["cost"] = _first(cost_obj.get("total_cost_usd"), data.get("cost_usd"))
+    out["duration"] = _first(cost_obj.get("total_duration_ms"), data.get("session_duration_ms"))
+    out["api_duration"] = _first(cost_obj.get("total_api_duration_ms"), data.get("api_duration_ms"))
+    out["lines_added"] = _first(cost_obj.get("total_lines_added"), data.get("lines_added"))
+    out["lines_removed"] = _first(cost_obj.get("total_lines_removed"), data.get("lines_removed"))
 
     # Booleans
     out["exceeds_200k"] = data.get("exceeds_200k_tokens", False)
@@ -149,7 +157,7 @@ def _render_sections(n, order, theme):
     pct = n["used_percentage"]
 
     total_input = (input_tokens or 0) + (cache_read or 0) + (cache_create or 0)
-    total_tokens = (input_tokens or 0) + (output_tokens or 0) + (cache_read or 0)
+    total_tokens = (input_tokens or 0) + (output_tokens or 0) + (cache_read or 0) + (cache_create or 0)
 
     for section in order:
         if section == "bar" and pct is not None:
@@ -318,7 +326,7 @@ _COMPACT_DROP = [
     "sessions", "tools", "latency", "context_size",
 ]
 _NARROW_DROP = _COMPACT_DROP + [
-    "cache", "burn", "lines", "budget", "agent",
+    "cache", "burn", "lines", "budget", "agent", "model",
 ]
 
 
@@ -470,7 +478,9 @@ def cmd_install(theme_name="default"):
             with open(settings_file, "r", encoding="utf-8") as f:
                 settings = json.load(f)
         except (json.JSONDecodeError, IOError):
-            print("Warning: could not parse existing settings.json, creating new one")
+            print("Warning: could not parse existing settings.json")
+            print("  Backup saved to: {}.bak".format(settings_file))
+            print("  Creating new settings with statusLine config only")
 
     # Build command
     cmd = "claude-status"
@@ -648,7 +658,8 @@ def main():
                         choices=["default", "minimal", "powerline",
                                  "nord", "tokyo-night", "gruvbox", "rose-pine",
                                  "custom"],
-                        help="Theme to use (default: default). "
+                        help="Theme for this render (default: default). "
+                             "Use --install --theme NAME or --setup to persist. "
                              "'custom' loads ~/.claude/claude-status-theme.json")
 
     args = parser.parse_args()

--- a/claude_statusline/git.py
+++ b/claude_statusline/git.py
@@ -8,6 +8,7 @@ import tempfile
 import time
 
 _CACHE_TTL = 5  # seconds
+_NO_GIT_CACHE_TTL = 60  # seconds — longer TTL when git is not available
 
 
 def _cache_file():
@@ -25,14 +26,21 @@ def _cache_file():
 
 
 def _read_cache():
-    """Read cached git branch if still fresh."""
+    """Read cached git branch if still fresh.
+
+    Uses a longer TTL for empty values (git not available) to avoid
+    repeated subprocess timeouts on systems without git.
+    """
     try:
         path = _cache_file()
         stat = os.stat(path)
-        if time.time() - stat.st_mtime > _CACHE_TTL:
-            return None
         with open(path, "r") as f:
-            return f.read().strip()
+            value = f.read().strip()
+        # Use longer TTL when git is not available (empty cache)
+        ttl = _NO_GIT_CACHE_TTL if not value else _CACHE_TTL
+        if time.time() - stat.st_mtime > ttl:
+            return None
+        return value
     except (OSError, IOError):
         return None
 

--- a/claude_statusline/sessions.py
+++ b/claude_statusline/sessions.py
@@ -12,6 +12,7 @@ import tempfile
 import time
 
 _CACHE_TTL = 30  # seconds — longer than git cache since this is heavier
+_TOOL_CACHE_TTL = 10  # seconds — shorter for active session metrics
 
 _CLAUDE_DIR = os.path.join(os.path.expanduser("~"), ".claude")
 _SESSIONS_DIR = os.path.join(_CLAUDE_DIR, "sessions")
@@ -39,12 +40,12 @@ def _cache_path(name):
     return os.path.join(_cache_dir(), name)
 
 
-def _read_cache(name):
+def _read_cache(name, ttl=None):
     """Read a cached JSON value if still fresh."""
     try:
         path = _cache_path(name)
         stat = os.stat(path)
-        if time.time() - stat.st_mtime > _CACHE_TTL:
+        if time.time() - stat.st_mtime > (ttl or _CACHE_TTL):
             return None
         with open(path, "r") as f:
             return json.load(f)
@@ -82,16 +83,17 @@ def get_today_session_count():
     Returns:
         Number of sessions started today, or 0 on error.
     """
-    cached = _read_cache("sessions_today")
+    today = _today_str()
+    cache_key = "sessions_{}".format(today)
+    cached = _read_cache(cache_key)
     if cached is not None:
         return cached.get("count", 0)
 
     count = 0
-    today = _today_str()
 
     try:
         if not os.path.isdir(_SESSIONS_DIR):
-            _write_cache("sessions_today", {"count": 0})
+            _write_cache(cache_key, {"count": 0})
             return 0
 
         now = time.time()
@@ -120,7 +122,7 @@ def get_today_session_count():
     except OSError:
         pass
 
-    _write_cache("sessions_today", {"count": count})
+    _write_cache(cache_key, {"count": count})
     return count
 
 
@@ -146,7 +148,7 @@ def get_session_tool_count(session_id):
     cache_key = "tools_{}".format(
         hashlib.md5(session_id.encode("utf-8", errors="replace")).hexdigest()[:12]
     )
-    cached = _read_cache(cache_key)
+    cached = _read_cache(cache_key, ttl=_TOOL_CACHE_TTL)
     if cached is not None:
         return cached.get("count", 0)
 

--- a/claude_statusline/sessions.py
+++ b/claude_statusline/sessions.py
@@ -53,8 +53,15 @@ def _read_cache(name, ttl=None):
         return None
 
 
+_last_cleanup = 0
+
+
 def _write_cache(name, value):
-    """Write a JSON value to the named cache file atomically."""
+    """Write a JSON value to the named cache file atomically.
+
+    Periodically cleans up stale cache files (at most once per hour).
+    """
+    global _last_cleanup
     target = _cache_path(name)
     tmp = target + ".tmp"
     try:
@@ -66,6 +73,28 @@ def _write_cache(name, value):
             os.unlink(tmp)
         except OSError:
             pass
+
+    # Periodic cleanup (at most once per hour)
+    now = time.time()
+    if now - _last_cleanup > 3600:
+        _last_cleanup = now
+        _cleanup_stale_cache()
+
+
+def _cleanup_stale_cache():
+    """Remove cache files older than 2 days to prevent accumulation."""
+    try:
+        cache_dir = _cache_dir()
+        now = time.time()
+        for entry in os.scandir(cache_dir):
+            if entry.is_file() and not entry.name.endswith(".tmp"):
+                try:
+                    if now - entry.stat().st_mtime > 172800:  # 2 days
+                        os.unlink(entry.path)
+                except OSError:
+                    pass
+    except OSError:
+        pass
 
 
 def _today_str():

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "claude-status"
-version = "0.2.1"
+version = "0.2.2"
 description = "Beautiful, informative status line for Claude Code — zero dependencies, cross-platform"
 readme = "README.md"
 license = {text = "MIT"}

--- a/tests/test_all.py
+++ b/tests/test_all.py
@@ -454,6 +454,32 @@ class TestRender(unittest.TestCase):
         self.assertNotIn("Opus", result)
         self.assertNotIn("Sonnet", result)
 
+    def test_zero_values_not_dropped(self):
+        """Zero values should be preserved, not treated as None."""
+        data = {
+            "context_window": {
+                "used_percentage": 0,
+                "context_window_size": 200_000,
+                "current_usage": {
+                    "input_tokens": 0,
+                    "output_tokens": 0,
+                    "cache_read_input_tokens": 0,
+                    "cache_creation_input_tokens": 0,
+                },
+            },
+            "cost": {
+                "total_cost_usd": 0,
+                "total_duration_ms": 0,
+                "total_lines_added": 0,
+                "total_lines_removed": 0,
+            },
+            "git_branch": "main",
+        }
+        result = render(data)
+        self.assertIsInstance(result, str)
+        # Cost of 0 should render as "0c" not disappear
+        self.assertIn("0c", result)
+
     def test_real_schema_full(self):
         """Test with a complete real Claude Code JSON payload."""
         data = {
@@ -1019,7 +1045,8 @@ class TestSessions(unittest.TestCase):
             sessions_mod._SESSIONS_DIR = sessions_dir
 
             # Clear cache to force re-read
-            _write_cache("sessions_today", None)
+            # Clear date-keyed cache
+            _write_cache("sessions_{}".format(time.strftime("%Y-%m-%d")), None)
 
             try:
                 count = get_today_session_count()
@@ -1401,7 +1428,7 @@ class TestResponsiveLayout(unittest.TestCase):
         """Narrow terminal (<80) should show only essentials."""
         from claude_statusline.cli import _apply_responsive
         sections = ["bar", "tokens", "cache", "cost", "burn",
-                    "git_extras", "version", "clock", "lines", "budget"]
+                    "git_extras", "version", "clock", "lines", "budget", "model"]
         result = _apply_responsive(sections, 60)
         self.assertIn("bar", result)
         self.assertIn("tokens", result)
@@ -1410,6 +1437,7 @@ class TestResponsiveLayout(unittest.TestCase):
         self.assertNotIn("burn", result)
         self.assertNotIn("lines", result)
         self.assertNotIn("budget", result)
+        self.assertNotIn("model", result)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Closes #21, #22, #23, #24, #25, #26, #27, #28, #29.

### Critical
- **#21** — `_normalize()` drops zero values: all numeric fields used `or` which treats `0` as falsy. Now uses `_first()` helper that checks `is not None`
- **#22** — `--theme` misleading UX: help text now says "per-render only" and directs to `--install --theme` or `--setup`

### Important
- **#23** — Burn rate excludes `cache_create` tokens, understating consumption
- **#24** — Tool count 30s cache too stale for active sessions → reduced to 10s
- **#25** — Compaction bar color used scaled pct → red bar at 55% real usage. Now uses raw pct for color
- **#26** — Session count cache key has no date → stale across midnight
- **#27** — Missing git binary causes repeated 2s subprocess timeouts every 5s → "not available" cached for 60s
- **#28** — Corrupt `settings.json` warning doesn't mention backup file exists

### Minor
- **#29** — Narrow layout keeps `model` (long string) → may wrap. Added to drop list

### Stats
- 142 tests passing (1 new)
- 8 files changed, 102 insertions, 38 deletions

## Test plan

- [x] All 142 tests pass
- [x] Zero cost/tokens render as "0c"/"0" instead of disappearing
- [x] Bar at 55% with 62% compaction shows green (not red)
- [x] Narrow layout drops model section
- [x] `--theme` help text updated