### PR TITLE
feat: v0.3.1 — output style, added dirs count, thinking effort level

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.1] - 2026-04-06
+
+### Added
+- **Output style indicator** — displays active output style (e.g., `style:explanatory`) when configured. Hidden when not set. Closes #35.
+- **Added directories count** — shows `dirs:+N` when extra workspace directories are added via `/add-dir`. Closes #36.
+- **Thinking effort level** — displays `effort:high` or `effort:low` when set to non-default. Reads from `~/.claude/settings.json` with 30s cache. Hidden at default (medium). Closes #37.
+
+### Changed
+- All themes updated with `output_style`, `added_dirs`, and `effort` sections
+- Minimal theme includes `effort` (high-impact setting worth showing even in compact view)
+- Responsive layout drops all three new sections in compact mode (<120 cols)
+
 ## [0.3.0] - 2026-04-05
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,52 @@
+# Project Rules — claude-statusline
+
+## Non-negotiable rules
+
+1. **NEVER add AI attribution** — No "Co-Authored-By", "Generated with", "Written by", or any reference to Claude, Gemini, or any AI tool in commits, PRs, release notes, documentation, or any output. Zero exceptions.
+
+2. **No secrets or credentials** — Never commit API keys, tokens, passwords, paths with real usernames, or any sensitive data. All paths in code/tests must use generic placeholders like `/home/user/projects/myapp`.
+
+3. **Zero external dependencies** — Pure Python stdlib only. No pip packages. This is a core selling point of the project. Never add dependencies without explicit approval.
+
+4. **No references to other projects** — Don't mention competitor tools, internal projects, company names, or other repos in code, commits, or docs.
+
+5. **High code quality** — This is a public open-source project on PyPI. Every change is visible to the community. Code must be production-grade.
+
+## Development practices
+
+- Always run the full test suite before committing
+- Always run the PR review plugin (all 4 agents: code-reviewer, test-analyzer, silent-failure-hunter, comment-analyzer) and iterate until zero issues
+- Check Gemini PR comments and address them
+- Keep CHANGELOG.md up to date with every version
+- Update README feature tables and examples when adding features
+- Bump version in both `__init__.py` and `pyproject.toml`
+- After merge, create a GitHub release to trigger PyPI publish
+- Close related GitHub issues after release
+- Install from PyPI and verify the release works
+
+## Code patterns
+
+- Use `_first()` helper for numeric fields (not `or` which drops zeros)
+- Use `_safe_num()` for coercing external numeric values
+- Use `isinstance()` checks before `.get()` on external JSON data
+- All section renderers must degrade gracefully — never crash
+- `render()` call in `main()` is wrapped in try/except as defense-in-depth
+- Cache reads use TTL-based file caching in user-scoped temp directories
+- Cache writes use atomic `os.replace()` pattern
+- Git operations use 5s cache TTL, "not available" state uses 60s TTL
+- Tool count uses 10s TTL, other session data uses 30s TTL
+
+## Testing
+
+- stdlib `unittest` only — no pytest, no mock library
+- Tests must be deterministic (provide explicit `git_branch` in test data, don't depend on environment)
+- Test all edge cases: present, absent, empty, zero, non-dict, non-list, corrupted JSON
+- Monkey-patch at the `cli_mod` level when testing section renderers
+- Clear cache files before tests that depend on fresh reads
+
+## SEO and discoverability
+
+- Keep pyproject.toml keywords comprehensive
+- README must have FAQ and Troubleshooting sections
+- Feature tables must list every metric with example output
+- Comparison table must be kept current

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 
 ```
 Line 1:  [████████░░░░░░░░░░░░] │ in:245K out:18K │ cache:41% │ $0.73 │ burn:37K/min │ 5h:34% 7d:18% ~2h │ (200K)
-Line 2:  12m05s │ +247 -38 │ ⎇ myapp/feat/statusline │ stash:2 │ ✦ refactor auth │ Opus │ v0.3.0 │ CC:2.1.92 │ 15:30
+Line 2:  12m05s │ +247 -38 │ ⎇ myapp/feat/statusline │ ✦ refactor auth │ Opus │ style:explanatory │ effort:high │ v0.3.1 │ CC:2.1.92 │ 15:30
 ```
 
 ## Quick Start
@@ -81,7 +81,7 @@ Restart Claude Code. That's it — two lines of pure signal at the bottom of you
 ### default — full detail, clean separators
 ```
 [████████░░░░░░░░░░░░] │ in:245K out:18K │ cache:41% │ $0.73 │ burn:37K/min │ 5h:34% 7d:18% ~2h │ (200K)
-12m05s │ +247 -38 │ ⎇ myapp/feat/statusline │ ✦ refactor auth │ Opus │ v0.3.0 │ CC:2.1.92 │ 15:30
+12m05s │ +247 -38 │ ⎇ myapp/feat/statusline │ ✦ refactor auth │ Opus │ v0.3.1 │ CC:2.1.92 │ 15:30
 ```
 
 ### minimal — just the essentials
@@ -93,7 +93,7 @@ Restart Claude Code. That's it — two lines of pure signal at the bottom of you
 ### powerline — Nerd Font separators
 ```
 ████████░░░░░░░░░░░░  in:245K out:18K  cache:41%  $0.73  burn:37K/min  5h:34% 7d:18% ~2h  (200K)
-12m05s  +247 -38  ⎇ feat/statusline  ✦ refactor auth  Opus  v0.3.0  CC:2.1.92  15:30
+12m05s  +247 -38  ⎇ feat/statusline  ✦ refactor auth  Opus  v0.3.1  CC:2.1.92  15:30
 ```
 
 ### nord — cool blue tones

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Restart Claude Code. That's it — two lines of pure signal at the bottom of you
 
 - **Zero dependencies** — pure Python stdlib. No `psutil`, no `colorama`, no compilation. Installs in under 2 seconds
 - **Two-line layout** — glanceable metrics on line 1, context details on line 2. Nothing gets truncated
-- **Every metric that matters** — 23 data points including burn rate (tokens/min) and rate limit tracking with reset countdown
+- **Every metric that matters** — 26 data points including burn rate (tokens/min), rate limit tracking, and effort level
 - **Rate limit awareness** — see your 5-hour and 7-day API usage at a glance with color-coded warnings
 - **Responsive layout** — automatically adapts to your terminal width (full/compact/narrow)
 - **7 built-in themes** — default, minimal, powerline, nord, tokyo-night, gruvbox, rose-pine
@@ -67,7 +67,10 @@ Restart Claude Code. That's it — two lines of pure signal at the bottom of you
 | Session Name | `✦ refactor auth` | Custom session name (via `--name` or `/rename`) |
 | Worktree | `wt:fix/bug-123` | Worktree branch indicator |
 | Model | `Opus 4.6 (1M context)` | Active model name |
-| Version | `v0.3.0` | claude-status version |
+| Output Style | `style:explanatory` | Active output style when set |
+| Added Dirs | `dirs:+2` | Extra directories added via `/add-dir` |
+| Effort Level | `effort:high` | Thinking effort (shown when non-default) |
+| Version | `v0.3.1` | claude-status version |
 | CC Version | `CC:2.1.92` | Claude Code application version |
 | Clock | `15:30` | Current time |
 

--- a/claude_statusline/__init__.py
+++ b/claude_statusline/__init__.py
@@ -1,3 +1,3 @@
 """claude-status: Beautiful status line for Claude Code."""
 
-__version__ = "0.3.0"
+__version__ = "0.3.1"

--- a/claude_statusline/cli.py
+++ b/claude_statusline/cli.py
@@ -154,7 +154,8 @@ def _normalize(data):
     # Output style
     style_obj = data.get("output_style")
     style_obj = style_obj if isinstance(style_obj, dict) else {}
-    out["output_style"] = style_obj.get("name") or ""
+    style_name = style_obj.get("name")
+    out["output_style"] = style_name if isinstance(style_name, str) and style_name else ""
 
     # Added directories count
     added_dirs = workspace.get("added_dirs")
@@ -814,7 +815,10 @@ def main():
     except KeyboardInterrupt:
         return
 
-    output = render(data, args.theme)
+    try:
+        output = render(data, args.theme)
+    except Exception:
+        output = ""
     if output:
         print(output)
 

--- a/claude_statusline/cli.py
+++ b/claude_statusline/cli.py
@@ -20,7 +20,7 @@ from .formatters import (
 )
 from .git import get_branch, get_git_extras
 from .sessions import (
-    get_budget_config, get_compaction_threshold,
+    get_budget_config, get_compaction_threshold, get_effort_level,
     get_session_tool_count, get_today_session_count,
 )
 from .themes import THEMES, get_theme
@@ -150,6 +150,15 @@ def _normalize(data):
     out["rate_limit_5h_resets"] = _safe_num(five_h.get("resets_at"))
     out["rate_limit_7d_pct"] = _safe_num(seven_d.get("used_percentage"))
     out["rate_limit_7d_resets"] = _safe_num(seven_d.get("resets_at"))
+
+    # Output style
+    style_obj = data.get("output_style")
+    style_obj = style_obj if isinstance(style_obj, dict) else {}
+    out["output_style"] = style_obj.get("name") or ""
+
+    # Added directories count
+    added_dirs = workspace.get("added_dirs")
+    out["added_dirs_count"] = len(added_dirs) if isinstance(added_dirs, list) else 0
 
     return out
 
@@ -364,6 +373,31 @@ def _render_sections(n, order, theme):
                 if parts:
                     sections.append(" ".join(parts))
 
+        elif section == "output_style":
+            style = n.get("output_style", "")
+            if style:
+                osc = tc.get("output_style", BRIGHT_BLACK)
+                sections.append(colorize("style:" + style, osc))
+
+        elif section == "added_dirs":
+            dirs_count = n.get("added_dirs_count", 0)
+            if dirs_count > 0:
+                adc = tc.get("added_dirs", BRIGHT_BLACK)
+                sections.append(colorize(
+                    "dirs:+{}".format(dirs_count), adc
+                ))
+
+        elif section == "effort":
+            effort = get_effort_level()
+            if effort:
+                if effort == "high":
+                    ec = tc.get("effort_high", BRIGHT_MAGENTA)
+                else:
+                    ec = tc.get("effort_low", BRIGHT_BLACK)
+                sections.append(colorize(
+                    "effort:" + effort, ec, BOLD
+                ))
+
         elif section == "git_extras":
             branch = n["git_branch"] or get_branch()
             if branch:
@@ -397,7 +431,7 @@ def _render_sections(n, order, theme):
 _COMPACT_DROP = [
     "git_extras", "version", "cc_version", "clock", "worktree",
     "sessions", "tools", "latency", "context_size", "session_name",
-    "rate_limits",
+    "rate_limits", "output_style", "added_dirs", "effort",
 ]
 _NARROW_DROP = _COMPACT_DROP + [
     "cache", "burn", "lines", "budget", "agent", "model",
@@ -483,6 +517,7 @@ def _demo_data():
         "workspace": {
             "project_dir": "/home/user/projects/myapp",
             "current_dir": "/home/user/projects/myapp/src",
+            "added_dirs": ["/home/user/projects/shared-lib"],
         },
         "model": {
             "display_name": "Opus 4.6 (1M context)",
@@ -490,6 +525,7 @@ def _demo_data():
         "session_id": "demo-session",
         "session_name": "refactor auth",
         "version": "2.1.92",
+        "output_style": {"name": "explanatory"},
         "rate_limits": {
             "five_hour": {
                 "used_percentage": 34,

--- a/claude_statusline/cli.py
+++ b/claude_statusline/cli.py
@@ -817,7 +817,8 @@ def main():
 
     try:
         output = render(data, args.theme)
-    except Exception:
+    except Exception as exc:
+        print("claude-status: render error: {}".format(exc), file=sys.stderr)
         output = ""
     if output:
         print(output)

--- a/claude_statusline/sessions.py
+++ b/claude_statusline/sessions.py
@@ -293,17 +293,22 @@ def get_effort_level():
     cached = _read_cache("effort_level")
     if cached is not None:
         val = cached.get("effort")
-        return val if val in _VALID_EFFORT_LEVELS else None
+        if val in _VALID_EFFORT_LEVELS and val != "medium":
+            return val
+        return None
 
     settings_path = os.path.join(_CLAUDE_DIR, "settings.json")
     effort = None
     try:
         with open(settings_path, "r", encoding="utf-8") as f:
             data = json.load(f)
+        if not isinstance(data, dict):
+            data = {}
         raw = data.get("effortLevel", "")
         if isinstance(raw, str) and raw.lower() in _VALID_EFFORT_LEVELS:
             effort = raw.lower()
-    except (OSError, IOError, json.JSONDecodeError, ValueError, TypeError):
+    except (OSError, IOError, json.JSONDecodeError, ValueError,
+            TypeError, AttributeError):
         pass
 
     # Only return non-default levels (medium is the default, skip it)

--- a/claude_statusline/sessions.py
+++ b/claude_statusline/sessions.py
@@ -275,3 +275,39 @@ def get_compaction_threshold():
     config = _read_status_config()
     val = config.get("threshold")
     return float(val) if val is not None else None
+
+
+_VALID_EFFORT_LEVELS = {"low", "medium", "high"}
+
+
+def get_effort_level():
+    """Read thinking effort level from ~/.claude/settings.json.
+
+    Valid values: "low", "medium", "high". Returns None if not
+    configured, invalid, or set to the default "medium".
+    Uses 30s cache to avoid hitting disk on every render.
+
+    Returns:
+        Effort level string ("low" or "high"), or None if medium/absent.
+    """
+    cached = _read_cache("effort_level")
+    if cached is not None:
+        val = cached.get("effort")
+        return val if val in _VALID_EFFORT_LEVELS else None
+
+    settings_path = os.path.join(_CLAUDE_DIR, "settings.json")
+    effort = None
+    try:
+        with open(settings_path, "r", encoding="utf-8") as f:
+            data = json.load(f)
+        raw = data.get("effortLevel", "")
+        if isinstance(raw, str) and raw.lower() in _VALID_EFFORT_LEVELS:
+            effort = raw.lower()
+    except (OSError, IOError, json.JSONDecodeError, ValueError, TypeError):
+        pass
+
+    # Only return non-default levels (medium is the default, skip it)
+    if effort == "medium":
+        effort = None
+    _write_cache("effort_level", {"effort": effort})
+    return effort

--- a/claude_statusline/sessions.py
+++ b/claude_statusline/sessions.py
@@ -309,7 +309,8 @@ def get_effort_level():
             effort = raw.lower()
     except (OSError, IOError, json.JSONDecodeError, ValueError,
             TypeError, AttributeError):
-        pass
+        # Don't cache failure — retry next cycle
+        return None
 
     # Only return non-default levels (medium is the default, skip it)
     if effort == "medium":

--- a/claude_statusline/themes.py
+++ b/claude_statusline/themes.py
@@ -55,8 +55,8 @@ THEMES = {
             "effort_low": colors.BRIGHT_BLACK,
         },
     },
-    # Minimal intentionally omits tools, cache, burn, budget, lines, and
-    # context_size to keep output compact — only essential metrics shown.
+    # Minimal shows only essential metrics — see line1/line2 lists below
+    # for exactly what's included. All other sections are omitted.
     "minimal": {
         "name": "minimal",
         "separator": " ",

--- a/claude_statusline/themes.py
+++ b/claude_statusline/themes.py
@@ -21,7 +21,8 @@ THEMES = {
         "line2": [
             "duration", "latency", "lines", "branch", "git_extras",
             "tools", "sessions", "session_name", "vim", "agent", "worktree",
-            "model", "version", "cc_version", "clock",
+            "model", "output_style", "added_dirs", "effort",
+            "version", "cc_version", "clock",
         ],
         "colors": {
             "separator": colors.BRIGHT_BLACK,
@@ -48,6 +49,10 @@ THEMES = {
             "rate_limit_ok": colors.GREEN,
             "rate_limit_warn": colors.YELLOW,
             "rate_limit_danger": colors.BRIGHT_RED,
+            "output_style": colors.BRIGHT_BLACK,
+            "added_dirs": colors.BRIGHT_BLACK,
+            "effort_high": colors.BRIGHT_MAGENTA,
+            "effort_low": colors.BRIGHT_BLACK,
         },
     },
     # Minimal intentionally omits tools, cache, burn, budget, lines, and
@@ -64,7 +69,7 @@ THEMES = {
         ],
         "line2": [
             "duration", "latency", "branch", "sessions", "session_name",
-            "model", "clock",
+            "model", "effort", "clock",
         ],
         "colors": {
             "separator": colors.BRIGHT_BLACK,
@@ -91,6 +96,10 @@ THEMES = {
             "rate_limit_ok": colors.GREEN,
             "rate_limit_warn": colors.YELLOW,
             "rate_limit_danger": colors.BRIGHT_RED,
+            "output_style": colors.BRIGHT_BLACK,
+            "added_dirs": colors.BRIGHT_BLACK,
+            "effort_high": colors.BRIGHT_MAGENTA,
+            "effort_low": colors.BRIGHT_BLACK,
         },
     },
     "powerline": {
@@ -107,7 +116,8 @@ THEMES = {
         "line2": [
             "duration", "latency", "lines", "branch", "git_extras",
             "tools", "sessions", "session_name", "vim", "agent", "worktree",
-            "model", "version", "cc_version", "clock",
+            "model", "output_style", "added_dirs", "effort",
+            "version", "cc_version", "clock",
         ],
         "colors": {
             "separator": colors.BRIGHT_BLACK,
@@ -134,6 +144,10 @@ THEMES = {
             "rate_limit_ok": colors.GREEN,
             "rate_limit_warn": colors.YELLOW,
             "rate_limit_danger": colors.BRIGHT_RED,
+            "output_style": colors.BRIGHT_BLACK,
+            "added_dirs": colors.BRIGHT_BLACK,
+            "effort_high": colors.BRIGHT_MAGENTA,
+            "effort_low": colors.BRIGHT_BLACK,
         },
     },
     "nord": {
@@ -150,7 +164,8 @@ THEMES = {
         "line2": [
             "duration", "latency", "lines", "branch", "git_extras",
             "tools", "sessions", "session_name", "vim", "agent", "worktree",
-            "model", "version", "cc_version", "clock",
+            "model", "output_style", "added_dirs", "effort",
+            "version", "cc_version", "clock",
         ],
         "colors": {
             "separator": colors.BRIGHT_BLACK,
@@ -177,6 +192,10 @@ THEMES = {
             "rate_limit_ok": colors.GREEN,
             "rate_limit_warn": colors.YELLOW,
             "rate_limit_danger": colors.BRIGHT_RED,
+            "output_style": colors.BRIGHT_BLACK,
+            "added_dirs": colors.BRIGHT_BLACK,
+            "effort_high": colors.BRIGHT_MAGENTA,
+            "effort_low": colors.BRIGHT_BLACK,
         },
     },
     "tokyo-night": {
@@ -193,7 +212,8 @@ THEMES = {
         "line2": [
             "duration", "latency", "lines", "branch", "git_extras",
             "tools", "sessions", "session_name", "vim", "agent", "worktree",
-            "model", "version", "cc_version", "clock",
+            "model", "output_style", "added_dirs", "effort",
+            "version", "cc_version", "clock",
         ],
         "colors": {
             "separator": colors.BRIGHT_BLACK,
@@ -220,6 +240,10 @@ THEMES = {
             "rate_limit_ok": colors.GREEN,
             "rate_limit_warn": colors.YELLOW,
             "rate_limit_danger": colors.BRIGHT_RED,
+            "output_style": colors.BRIGHT_BLACK,
+            "added_dirs": colors.BRIGHT_BLACK,
+            "effort_high": colors.BRIGHT_MAGENTA,
+            "effort_low": colors.BRIGHT_BLACK,
         },
     },
     "gruvbox": {
@@ -236,7 +260,8 @@ THEMES = {
         "line2": [
             "duration", "latency", "lines", "branch", "git_extras",
             "tools", "sessions", "session_name", "vim", "agent", "worktree",
-            "model", "version", "cc_version", "clock",
+            "model", "output_style", "added_dirs", "effort",
+            "version", "cc_version", "clock",
         ],
         "colors": {
             "separator": colors.BRIGHT_BLACK,
@@ -263,6 +288,10 @@ THEMES = {
             "rate_limit_ok": colors.GREEN,
             "rate_limit_warn": colors.YELLOW,
             "rate_limit_danger": colors.BRIGHT_RED,
+            "output_style": colors.BRIGHT_BLACK,
+            "added_dirs": colors.BRIGHT_BLACK,
+            "effort_high": colors.BRIGHT_MAGENTA,
+            "effort_low": colors.BRIGHT_BLACK,
         },
     },
     "rose-pine": {
@@ -279,7 +308,8 @@ THEMES = {
         "line2": [
             "duration", "latency", "lines", "branch", "git_extras",
             "tools", "sessions", "session_name", "vim", "agent", "worktree",
-            "model", "version", "cc_version", "clock",
+            "model", "output_style", "added_dirs", "effort",
+            "version", "cc_version", "clock",
         ],
         "colors": {
             "separator": colors.BRIGHT_BLACK,
@@ -306,6 +336,10 @@ THEMES = {
             "rate_limit_ok": colors.GREEN,
             "rate_limit_warn": colors.YELLOW,
             "rate_limit_danger": colors.BRIGHT_RED,
+            "output_style": colors.BRIGHT_BLACK,
+            "added_dirs": colors.BRIGHT_BLACK,
+            "effort_high": colors.BRIGHT_MAGENTA,
+            "effort_low": colors.BRIGHT_BLACK,
         },
     },
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "claude-status"
-version = "0.3.0"
+version = "0.3.1"
 description = "Beautiful, informative status line for Claude Code — zero dependencies, cross-platform"
 readme = "README.md"
 license = {text = "MIT"}

--- a/tests/test_all.py
+++ b/tests/test_all.py
@@ -1696,5 +1696,229 @@ class TestFmtCountdown(unittest.TestCase):
         self.assertEqual(fmt_countdown(None), "")
 
 
+# ─── cli.py — output style section ──────────────────────────────────
+
+class TestOutputStyle(unittest.TestCase):
+    def _base_data(self, **extra):
+        data = {
+            "context_window": {"used_percentage": 30,
+                               "current_usage": {"input_tokens": 5000}},
+            "cost": {"total_cost_usd": 0.50, "total_duration_ms": 60000},
+            "git_branch": "main",
+        }
+        data.update(extra)
+        return data
+
+    def test_output_style_displayed(self):
+        data = self._base_data(output_style={"name": "explanatory"})
+        result = render(data)
+        self.assertIn("style:explanatory", result)
+
+    def test_output_style_hidden_when_absent(self):
+        data = self._base_data()
+        result = render(data)
+        self.assertNotIn("style:", result)
+
+    def test_output_style_hidden_when_empty(self):
+        data = self._base_data(output_style={"name": ""})
+        result = render(data)
+        self.assertNotIn("style:", result)
+
+    def test_output_style_non_dict(self):
+        """Non-dict output_style should not crash."""
+        data = self._base_data(output_style="concise")
+        result = render(data)
+        self.assertIsInstance(result, str)
+
+    def test_output_style_null_name(self):
+        data = self._base_data(output_style={"name": None})
+        result = render(data)
+        self.assertNotIn("style:", result)
+
+
+# ─── cli.py — added directories section ─────────────────────────────
+
+class TestAddedDirs(unittest.TestCase):
+    def _base_data(self, **extra):
+        data = {
+            "context_window": {"used_percentage": 30,
+                               "current_usage": {"input_tokens": 5000}},
+            "cost": {"total_cost_usd": 0.50, "total_duration_ms": 60000},
+            "git_branch": "main",
+        }
+        data.update(extra)
+        return data
+
+    def test_added_dirs_displayed(self):
+        data = self._base_data(workspace={
+            "project_dir": "/home/user/myapp",
+            "added_dirs": ["/lib1", "/lib2"],
+        })
+        result = render(data)
+        self.assertIn("dirs:+2", result)
+
+    def test_added_dirs_hidden_when_empty(self):
+        data = self._base_data(workspace={
+            "project_dir": "/home/user/myapp",
+            "added_dirs": [],
+        })
+        result = render(data)
+        self.assertNotIn("dirs:", result)
+
+    def test_added_dirs_hidden_when_absent(self):
+        data = self._base_data()
+        result = render(data)
+        self.assertNotIn("dirs:", result)
+
+    def test_added_dirs_non_list(self):
+        """Non-list added_dirs should not crash."""
+        data = self._base_data(workspace={
+            "project_dir": "/home/user/myapp",
+            "added_dirs": "not a list",
+        })
+        result = render(data)
+        self.assertIsInstance(result, str)
+        self.assertNotIn("dirs:", result)
+
+
+# ─── sessions.py — effort level ─────────────────────────────────────
+
+class TestEffortLevel(unittest.TestCase):
+    def test_effort_high(self):
+        from claude_statusline.sessions import get_effort_level, _cache_path
+        import claude_statusline.sessions as sessions_mod
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            settings_file = os.path.join(tmpdir, "settings.json")
+            with open(settings_file, "w") as f:
+                json.dump({"effortLevel": "high"}, f)
+
+            orig = sessions_mod._CLAUDE_DIR
+            sessions_mod._CLAUDE_DIR = tmpdir
+            try:
+                os.unlink(_cache_path("effort_level"))
+            except OSError:
+                pass
+            try:
+                result = get_effort_level()
+                self.assertEqual(result, "high")
+            finally:
+                sessions_mod._CLAUDE_DIR = orig
+
+    def test_effort_medium_returns_none(self):
+        """Medium is the default — should return None to hide the section."""
+        from claude_statusline.sessions import get_effort_level, _cache_path
+        import claude_statusline.sessions as sessions_mod
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            settings_file = os.path.join(tmpdir, "settings.json")
+            with open(settings_file, "w") as f:
+                json.dump({"effortLevel": "medium"}, f)
+
+            orig = sessions_mod._CLAUDE_DIR
+            sessions_mod._CLAUDE_DIR = tmpdir
+            try:
+                os.unlink(_cache_path("effort_level"))
+            except OSError:
+                pass
+            try:
+                result = get_effort_level()
+                self.assertIsNone(result)
+            finally:
+                sessions_mod._CLAUDE_DIR = orig
+
+    def test_effort_low(self):
+        from claude_statusline.sessions import get_effort_level, _cache_path
+        import claude_statusline.sessions as sessions_mod
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            settings_file = os.path.join(tmpdir, "settings.json")
+            with open(settings_file, "w") as f:
+                json.dump({"effortLevel": "low"}, f)
+
+            orig = sessions_mod._CLAUDE_DIR
+            sessions_mod._CLAUDE_DIR = tmpdir
+            try:
+                os.unlink(_cache_path("effort_level"))
+            except OSError:
+                pass
+            try:
+                result = get_effort_level()
+                self.assertEqual(result, "low")
+            finally:
+                sessions_mod._CLAUDE_DIR = orig
+
+    def test_effort_absent_returns_none(self):
+        from claude_statusline.sessions import get_effort_level, _cache_path
+        import claude_statusline.sessions as sessions_mod
+
+        orig = sessions_mod._CLAUDE_DIR
+        sessions_mod._CLAUDE_DIR = "/nonexistent/path"
+        try:
+            os.unlink(_cache_path("effort_level"))
+        except OSError:
+            pass
+        try:
+            result = get_effort_level()
+            self.assertIsNone(result)
+        finally:
+            sessions_mod._CLAUDE_DIR = orig
+
+    def test_effort_invalid_value(self):
+        from claude_statusline.sessions import get_effort_level, _cache_path
+        import claude_statusline.sessions as sessions_mod
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            settings_file = os.path.join(tmpdir, "settings.json")
+            with open(settings_file, "w") as f:
+                json.dump({"effortLevel": "ultrathink"}, f)
+
+            orig = sessions_mod._CLAUDE_DIR
+            sessions_mod._CLAUDE_DIR = tmpdir
+            try:
+                os.unlink(_cache_path("effort_level"))
+            except OSError:
+                pass
+            try:
+                result = get_effort_level()
+                self.assertIsNone(result)
+            finally:
+                sessions_mod._CLAUDE_DIR = orig
+
+
+class TestEffortSection(unittest.TestCase):
+    def test_effort_high_rendered(self):
+        import claude_statusline.cli as cli_mod
+        orig = cli_mod.get_effort_level
+        cli_mod.get_effort_level = lambda: "high"
+        try:
+            data = {
+                "context_window": {"used_percentage": 30,
+                                   "current_usage": {"input_tokens": 5000}},
+                "cost": {"total_cost_usd": 0.50, "total_duration_ms": 60000},
+                "git_branch": "main",
+            }
+            result = render(data)
+            self.assertIn("effort:high", result)
+        finally:
+            cli_mod.get_effort_level = orig
+
+    def test_effort_hidden_when_none(self):
+        import claude_statusline.cli as cli_mod
+        orig = cli_mod.get_effort_level
+        cli_mod.get_effort_level = lambda: None
+        try:
+            data = {
+                "context_window": {"used_percentage": 30,
+                                   "current_usage": {"input_tokens": 5000}},
+                "cost": {"total_cost_usd": 0.50, "total_duration_ms": 60000},
+                "git_branch": "main",
+            }
+            result = render(data)
+            self.assertNotIn("effort:", result)
+        finally:
+            cli_mod.get_effort_level = orig
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_all.py
+++ b/tests/test_all.py
@@ -1919,6 +1919,112 @@ class TestEffortSection(unittest.TestCase):
         finally:
             cli_mod.get_effort_level = orig
 
+    def test_effort_low_rendered(self):
+        """Effort low should display with dim color."""
+        import claude_statusline.cli as cli_mod
+        orig = cli_mod.get_effort_level
+        cli_mod.get_effort_level = lambda: "low"
+        try:
+            data = {
+                "context_window": {"used_percentage": 30,
+                                   "current_usage": {"input_tokens": 5000}},
+                "cost": {"total_cost_usd": 0.50, "total_duration_ms": 60000},
+                "git_branch": "main",
+            }
+            result = render(data)
+            self.assertIn("effort:low", result)
+        finally:
+            cli_mod.get_effort_level = orig
+
+
+class TestEffortLevelCorrupted(unittest.TestCase):
+    def test_corrupted_settings_returns_none(self):
+        """Invalid JSON in settings.json should return None gracefully."""
+        from claude_statusline.sessions import get_effort_level, _cache_path
+        import claude_statusline.sessions as sessions_mod
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            settings_file = os.path.join(tmpdir, "settings.json")
+            with open(settings_file, "w") as f:
+                f.write("{not valid json")
+
+            orig = sessions_mod._CLAUDE_DIR
+            sessions_mod._CLAUDE_DIR = tmpdir
+            try:
+                os.unlink(_cache_path("effort_level"))
+            except OSError:
+                pass
+            try:
+                result = get_effort_level()
+                self.assertIsNone(result)
+            finally:
+                sessions_mod._CLAUDE_DIR = orig
+
+    def test_non_dict_settings_returns_none(self):
+        """settings.json containing a JSON array should not crash."""
+        from claude_statusline.sessions import get_effort_level, _cache_path
+        import claude_statusline.sessions as sessions_mod
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            settings_file = os.path.join(tmpdir, "settings.json")
+            with open(settings_file, "w") as f:
+                json.dump([1, 2, 3], f)
+
+            orig = sessions_mod._CLAUDE_DIR
+            sessions_mod._CLAUDE_DIR = tmpdir
+            try:
+                os.unlink(_cache_path("effort_level"))
+            except OSError:
+                pass
+            try:
+                result = get_effort_level()
+                self.assertIsNone(result)
+            finally:
+                sessions_mod._CLAUDE_DIR = orig
+
+
+class TestAddedDirsExtra(unittest.TestCase):
+    def test_single_added_dir(self):
+        """Single added directory should show dirs:+1."""
+        data = {
+            "context_window": {"used_percentage": 30,
+                               "current_usage": {"input_tokens": 5000}},
+            "cost": {"total_cost_usd": 0.50, "total_duration_ms": 60000},
+            "git_branch": "main",
+            "workspace": {
+                "project_dir": "/home/user/myapp",
+                "added_dirs": ["/lib1"],
+            },
+        }
+        result = render(data)
+        self.assertIn("dirs:+1", result)
+
+
+class TestOutputStyleExtra(unittest.TestCase):
+    def test_output_style_non_string_name(self):
+        """Non-string name value should not crash."""
+        data = {
+            "context_window": {"used_percentage": 30,
+                               "current_usage": {"input_tokens": 5000}},
+            "cost": {"total_cost_usd": 0.50, "total_duration_ms": 60000},
+            "git_branch": "main",
+            "output_style": {"name": ["not", "a", "string"]},
+        }
+        result = render(data)
+        self.assertNotIn("style:", result)
+
+    def test_output_style_missing_name_key(self):
+        """output_style dict without name key should not crash."""
+        data = {
+            "context_window": {"used_percentage": 30,
+                               "current_usage": {"input_tokens": 5000}},
+            "cost": {"total_cost_usd": 0.50, "total_duration_ms": 60000},
+            "git_branch": "main",
+            "output_style": {},
+        }
+        result = render(data)
+        self.assertNotIn("style:", result)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

Closes #35, #36, #37.

### Output Style Indicator (#35)
Shows active output style when configured:
```
style:explanatory
```
Hidden when not set. Handles non-dict and null values gracefully.

### Added Directories Count (#36)
Shows count of extra workspace directories added via `/add-dir`:
```
dirs:+2
```
Hidden when no extra directories present. Handles non-list values gracefully.

### Thinking Effort Level (#37)
Shows current effort level when set to non-default:
```
effort:high
```
- Reads from `~/.claude/settings.json` with 30s cache
- Hidden when set to "medium" (default) or absent
- Color-coded: bold magenta for high, dim for low
- Validates against known values (low/medium/high)

### Stats
- 183 tests passing (16 new)
- Zero dependencies maintained
- 358 lines added across 8 files
- All 7 themes updated with new sections and color keys
- Responsive layout drops all three in compact mode

## Test plan

- [x] All 183 tests pass
- [x] Output style: present, absent, empty, non-dict, null name
- [x] Added dirs: present, absent, empty list, non-list
- [x] Effort: high, low, medium (returns None), absent, invalid value
- [x] Effort section renders when high, hidden when None
- [x] Demo shows all new sections
- [x] No secrets, credentials, or AI attribution in diff
- [x] No new dependencies