### PR TITLE
fix: rate limit reset countdown using wrong time units

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.2] - 2026-04-08
+
+### Fixed
+- **Rate limit reset countdown was showing wrong time** — `resets_at` is Unix epoch seconds per Claude Code docs, but was being treated as milliseconds. Now correctly converts seconds to milliseconds in `_normalize()`. Closes #39.
+- Demo data updated to use seconds for `resets_at` (matching real Claude Code behavior)
+
 ## [0.3.1] - 2026-04-06
 
 ### Added

--- a/claude_statusline/__init__.py
+++ b/claude_statusline/__init__.py
@@ -1,3 +1,3 @@
 """claude-status: Beautiful status line for Claude Code."""
 
-__version__ = "0.3.1"
+__version__ = "0.3.2"

--- a/claude_statusline/cli.py
+++ b/claude_statusline/cli.py
@@ -147,9 +147,13 @@ def _normalize(data):
     seven_d = rl.get("seven_day")
     seven_d = seven_d if isinstance(seven_d, dict) else {}
     out["rate_limit_5h_pct"] = _safe_num(five_h.get("used_percentage"))
-    out["rate_limit_5h_resets"] = _safe_num(five_h.get("resets_at"))
     out["rate_limit_7d_pct"] = _safe_num(seven_d.get("used_percentage"))
-    out["rate_limit_7d_resets"] = _safe_num(seven_d.get("resets_at"))
+    # resets_at is Unix epoch seconds per Claude Code docs — convert to ms
+    # so fmt_countdown() can use a consistent ms-based pipeline
+    resets_5h = _safe_num(five_h.get("resets_at"))
+    out["rate_limit_5h_resets"] = resets_5h * 1000 if resets_5h is not None else None
+    resets_7d = _safe_num(seven_d.get("resets_at"))
+    out["rate_limit_7d_resets"] = resets_7d * 1000 if resets_7d is not None else None
 
     # Output style
     style_obj = data.get("output_style")
@@ -530,11 +534,11 @@ def _demo_data():
         "rate_limits": {
             "five_hour": {
                 "used_percentage": 34,
-                "resets_at": int(time.time() * 1000) + 7_200_000,
+                "resets_at": int(time.time()) + 7_200,  # 2 hours from now (seconds)
             },
             "seven_day": {
                 "used_percentage": 18,
-                "resets_at": int(time.time() * 1000) + 432_000_000,
+                "resets_at": int(time.time()) + 432_000,  # 5 days from now (seconds)
             },
         },
     }

--- a/claude_statusline/cli.py
+++ b/claude_statusline/cli.py
@@ -149,7 +149,7 @@ def _normalize(data):
     out["rate_limit_5h_pct"] = _safe_num(five_h.get("used_percentage"))
     out["rate_limit_7d_pct"] = _safe_num(seven_d.get("used_percentage"))
     # resets_at is Unix epoch seconds per Claude Code docs — convert to ms
-    # so fmt_countdown() can use a consistent ms-based pipeline
+    # for fmt_countdown() which expects milliseconds
     resets_5h = _safe_num(five_h.get("resets_at"))
     out["rate_limit_5h_resets"] = resets_5h * 1000 if resets_5h is not None else None
     resets_7d = _safe_num(seven_d.get("resets_at"))

--- a/claude_statusline/cli.py
+++ b/claude_statusline/cli.py
@@ -146,14 +146,14 @@ def _normalize(data):
     five_h = five_h if isinstance(five_h, dict) else {}
     seven_d = rl.get("seven_day")
     seven_d = seven_d if isinstance(seven_d, dict) else {}
-    out["rate_limit_5h_pct"] = _safe_num(five_h.get("used_percentage"))
-    out["rate_limit_7d_pct"] = _safe_num(seven_d.get("used_percentage"))
     # resets_at is Unix epoch seconds per Claude Code docs — convert to ms
     # for fmt_countdown() which expects milliseconds
-    resets_5h = _safe_num(five_h.get("resets_at"))
-    out["rate_limit_5h_resets"] = resets_5h * 1000 if resets_5h is not None else None
-    resets_7d = _safe_num(seven_d.get("resets_at"))
-    out["rate_limit_7d_resets"] = resets_7d * 1000 if resets_7d is not None else None
+    for period, rl_dict in [("5h", five_h), ("7d", seven_d)]:
+        out["rate_limit_{}_pct".format(period)] = _safe_num(rl_dict.get("used_percentage"))
+        resets_sec = _safe_num(rl_dict.get("resets_at"))
+        out["rate_limit_{}_resets".format(period)] = (
+            resets_sec * 1000 if resets_sec is not None else None
+        )
 
     # Output style
     style_obj = data.get("output_style")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "claude-status"
-version = "0.3.1"
+version = "0.3.2"
 description = "Beautiful, informative status line for Claude Code — zero dependencies, cross-platform"
 readme = "README.md"
 license = {text = "MIT"}

--- a/tests/test_all.py
+++ b/tests/test_all.py
@@ -1499,8 +1499,8 @@ class TestRateLimits(unittest.TestCase):
 
     def test_rate_limits_with_countdown(self):
         """Reset countdown should appear when resets_at is in the future."""
-        future_ms = int(time.time() * 1000) + 7_200_000  # 2 hours from now
-        data = self._data_with_limits(five_h_pct=50, five_h_resets=future_ms)
+        future_sec = int(time.time()) + 7_200  # 2 hours from now (seconds)
+        data = self._data_with_limits(five_h_pct=50, five_h_resets=future_sec)
         result = render(data)
         self.assertIn("5h:50%", result)
         self.assertIn("~", result)  # countdown prefix
@@ -1532,14 +1532,51 @@ class TestRateLimits(unittest.TestCase):
 
     def test_rate_limits_nearest_reset(self):
         """Should show countdown to the nearest reset when both present."""
-        now = int(time.time() * 1000)
+        now = int(time.time())
         data = self._data_with_limits(
-            five_h_pct=50, five_h_resets=now + 3_600_000,    # 1h
-            seven_d_pct=20, seven_d_resets=now + 86_400_000,  # 24h
+            five_h_pct=50, five_h_resets=now + 3_600,      # 1h (seconds)
+            seven_d_pct=20, seven_d_resets=now + 86_400,   # 24h (seconds)
         )
         result = render(data)
         # Should show ~59m or ~1h, not ~24h
         self.assertIn("~", result)
+
+
+class TestRateLimitsResetConversion(unittest.TestCase):
+    """Verify resets_at seconds-to-milliseconds conversion."""
+
+    def test_resets_at_seconds_converted_to_ms(self):
+        """resets_at in seconds should produce a valid countdown."""
+        from claude_statusline.cli import _normalize
+        # Real Claude Code sends epoch seconds (roughly 1.7 billion)
+        future_sec = int(time.time()) + 3600  # 1 hour from now
+        data = {
+            "rate_limits": {
+                "five_hour": {
+                    "used_percentage": 50,
+                    "resets_at": future_sec,
+                },
+            },
+        }
+        n = _normalize(data)
+        # Should be converted to milliseconds internally
+        self.assertIsNotNone(n["rate_limit_5h_resets"])
+        self.assertGreater(n["rate_limit_5h_resets"], future_sec)
+        # Should be roughly future_sec * 1000
+        self.assertAlmostEqual(
+            n["rate_limit_5h_resets"], future_sec * 1000, delta=1000
+        )
+
+    def test_resets_at_none_stays_none(self):
+        """Missing resets_at should remain None after conversion."""
+        from claude_statusline.cli import _normalize
+        data = {
+            "rate_limits": {
+                "five_hour": {"used_percentage": 50},
+            },
+        }
+        n = _normalize(data)
+        self.assertIsNone(n["rate_limit_5h_resets"])
 
 
 class TestRateLimitsMalformed(unittest.TestCase):


### PR DESCRIPTION
## Summary

Closes #39.

The `rate_limits.*.resets_at` field from Claude Code uses **Unix epoch seconds** (per [official docs](https://code.claude.com/docs/en/statusline)), but `fmt_countdown()` expected milliseconds. This caused the reset countdown to display wildly incorrect values.

### Fix
Convert `resets_at` from seconds to milliseconds in `_normalize()`:
```python
resets_5h = _safe_num(five_h.get("resets_at"))
out["rate_limit_5h_resets"] = resets_5h * 1000 if resets_5h is not None else None
```

### Changes
- `_normalize()` converts `resets_at` seconds to ms (the internal pipeline format)
- Demo data updated to use seconds (matching real Claude Code behavior)
- 2 new tests verify the seconds-to-ms conversion
- Existing rate limit tests updated to use seconds

### Stats
- 191 tests passing (2 new)
- No new dependencies

## Test plan

- [x] All 191 tests pass
- [x] New test verifies seconds are converted to ms with `assertAlmostEqual`
- [x] New test verifies None stays None after conversion
- [x] Existing countdown tests updated to use seconds
- [x] Demo output shows correct ~2h countdown
- [x] No secrets, credentials, or AI attribution
- [x] Code review passed with zero issues