### PR TITLE
fix: rebalance Line 1/Line 2 to prevent Line 2 disappearing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.2] - 2026-04-10
+
+### Fixed
+- **Line 2 disappearing on some terminals** — rebalanced default layout by moving `rate_limits` and `context_size` from Line 1 to Line 2, keeping Line 1 under ~90 characters. This works around a Claude Code rendering limitation (anthropics/claude-code#28750) where long Line 1 silently drops all subsequent lines. Closes #52.
+
+### Changed
+- Default, powerline, nord, tokyo-night, gruvbox, rose-pine themes all rebalanced
+- Line 2 now starts with rate limits and context size for immediate visibility
+- README FAQ documents the Line 2 visibility limitation and workarounds
+
 ## [0.4.1] - 2026-04-10
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ The setup wizard walks you through theme selection, budget configuration, and in
 ### default — full detail, clean separators
 ```
 [████████░░░░░░░░░░░░] │ in:245K out:18K │ cache:41% │ $0.73 │ burn:37K/min
-5h:34% 7d:18% ~2h │ (200K) │ 12m05s │ +247 -38 │ ⎇ myapp/feat/statusline │ ✦ refactor auth │ v0.4.2 │ 15:30
+5h:34% 7d:18% ~2h │ (200K) │ 12m05s │ +247 -38 │ ⎇ myapp/feat/statusline │ ✦ refactor auth │ effort:high │ v0.4.2 │ 15:30
 ```
 
 ### minimal — just the essentials
@@ -94,7 +94,7 @@ The setup wizard walks you through theme selection, budget configuration, and in
 ### powerline — Nerd Font separators
 ```
 ████████░░░░░░░░░░░░  in:245K out:18K  cache:41%  $0.73  burn:37K/min
-5h:34% 7d:18% ~2h  (200K)  12m05s  +247 -38  ⎇ feat/statusline  ✦ refactor auth  v0.4.2  15:30
+5h:34% 7d:18% ~2h  (200K)  12m05s  +247 -38  ⎇ myapp/feat/statusline  ✦ refactor auth  effort:high  v0.4.2  15:30
 ```
 
 ### focus — single line, minimal footprint

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 
 ```
 Line 1:  [████████░░░░░░░░░░░░] │ in:245K out:18K │ cache:41% │ $0.73 │ burn:37K/min
-Line 2:  5h:34% 7d:18% ~2h │ (200K) │ 12m05s │ +247 -38 │ ⎇ myapp/feat/statusline │ ✦ refactor auth │ effort:high │ v0.4.2 │ 15:30
+Line 2:  5h:34% 7d:18% ~2h │ (200K) │ 12m05s │ +247 -38 │ ⎇ myapp/feat/statusline │ ✦ refactor auth │ Opus │ effort:high │ v0.4.2 │ CC:2.1.92 │ 15:30
 ```
 
 ## 30-Second Setup
@@ -82,7 +82,7 @@ The setup wizard walks you through theme selection, budget configuration, and in
 ### default — full detail, clean separators
 ```
 [████████░░░░░░░░░░░░] │ in:245K out:18K │ cache:41% │ $0.73 │ burn:37K/min
-5h:34% 7d:18% ~2h │ (200K) │ 12m05s │ +247 -38 │ ⎇ myapp/feat/statusline │ ✦ refactor auth │ effort:high │ v0.4.2 │ 15:30
+5h:34% 7d:18% ~2h │ (200K) │ 12m05s │ +247 -38 │ ⎇ myapp/feat/statusline │ ✦ refactor auth │ Opus │ effort:high │ v0.4.2 │ CC:2.1.92 │ 15:30
 ```
 
 ### minimal — just the essentials
@@ -94,7 +94,7 @@ The setup wizard walks you through theme selection, budget configuration, and in
 ### powerline — Nerd Font separators
 ```
 ████████░░░░░░░░░░░░  in:245K out:18K  cache:41%  $0.73  burn:37K/min
-5h:34% 7d:18% ~2h  (200K)  12m05s  +247 -38  ⎇ myapp/feat/statusline  ✦ refactor auth  effort:high  v0.4.2  15:30
+5h:34% 7d:18% ~2h  (200K)  12m05s  +247 -38  ⎇ myapp/feat/statusline  ✦ refactor auth  Opus  effort:high  v0.4.2  CC:2.1.92  15:30
 ```
 
 ### focus — single line, minimal footprint
@@ -255,7 +255,7 @@ By default, after each assistant message. Add `"refreshInterval": 10` to your st
 Yes — use the `focus` theme: `claude-status --install --theme focus`. It shows only the essentials on one line.
 
 **Why is only Line 1 showing / Line 2 is missing?**
-This is a known Claude Code rendering limitation where long Line 1 output causes Line 2 to be silently dropped. We've optimized the default layout to keep Line 1 short, but if you still see this, try the `focus` theme (`claude-status --install --theme focus`) for a guaranteed single-line display, or widen your terminal to 130+ columns.
+This is a known Claude Code rendering limitation where long Line 1 output causes Line 2 to be silently dropped. We've optimized all multi-line theme layouts to keep Line 1 short, but if you still see this, try the `focus` theme (`claude-status --install --theme focus`) for a guaranteed single-line display, or widen your terminal to 130+ columns.
 
 **Does it add any latency to Claude Code?**
 No. It runs as a pure stdin-to-stdout pipe in single-digit milliseconds. No daemon, no network calls, no background processes.

--- a/README.md
+++ b/README.md
@@ -10,8 +10,8 @@
 [![Downloads](https://img.shields.io/pypi/dm/claude-status)](https://pypi.org/project/claude-status/)
 
 ```
-Line 1:  [████████░░░░░░░░░░░░] │ in:245K out:18K │ cache:41% │ $0.73 │ burn:37K/min │ 5h:34% 7d:18% ~2h │ (200K)
-Line 2:  12m05s │ +247 -38 │ ⎇ myapp/feat/statusline │ ✦ refactor auth │ Opus │ effort:high │ v0.4.0 │ CC:2.1.92 │ 15:30
+Line 1:  [████████░░░░░░░░░░░░] │ in:245K out:18K │ cache:41% │ $0.73 │ burn:37K/min
+Line 2:  5h:34% 7d:18% ~2h │ (200K) │ 12m05s │ +247 -38 │ ⎇ myapp/feat/statusline │ ✦ refactor auth │ effort:high │ v0.4.2 │ 15:30
 ```
 
 ## 30-Second Setup
@@ -71,7 +71,7 @@ The setup wizard walks you through theme selection, budget configuration, and in
 | Output Style | `style:explanatory` | Active output style when set |
 | Added Dirs | `dirs:+2` | Extra directories added via `/add-dir` |
 | Effort Level | `effort:high` | Thinking effort (shown when non-default) |
-| Version | `v0.4.0` | claude-status version |
+| Version | `v0.4.2` | claude-status version |
 | CC Version | `CC:2.1.92` | Claude Code application version |
 | Clock | `15:30` | Current time |
 
@@ -81,8 +81,8 @@ The setup wizard walks you through theme selection, budget configuration, and in
 
 ### default — full detail, clean separators
 ```
-[████████░░░░░░░░░░░░] │ in:245K out:18K │ cache:41% │ $0.73 │ burn:37K/min │ 5h:34% 7d:18% ~2h │ (200K)
-12m05s │ +247 -38 │ ⎇ myapp/feat/statusline │ ✦ refactor auth │ Opus │ v0.4.0 │ CC:2.1.92 │ 15:30
+[████████░░░░░░░░░░░░] │ in:245K out:18K │ cache:41% │ $0.73 │ burn:37K/min
+5h:34% 7d:18% ~2h │ (200K) │ 12m05s │ +247 -38 │ ⎇ myapp/feat/statusline │ ✦ refactor auth │ v0.4.2 │ 15:30
 ```
 
 ### minimal — just the essentials
@@ -93,8 +93,8 @@ The setup wizard walks you through theme selection, budget configuration, and in
 
 ### powerline — Nerd Font separators
 ```
-████████░░░░░░░░░░░░  in:245K out:18K  cache:41%  $0.73  burn:37K/min  5h:34% 7d:18% ~2h  (200K)
-12m05s  +247 -38  ⎇ feat/statusline  ✦ refactor auth  Opus  v0.4.0  CC:2.1.92  15:30
+████████░░░░░░░░░░░░  in:245K out:18K  cache:41%  $0.73  burn:37K/min
+5h:34% 7d:18% ~2h  (200K)  12m05s  +247 -38  ⎇ feat/statusline  ✦ refactor auth  v0.4.2  15:30
 ```
 
 ### focus — single line, minimal footprint
@@ -253,6 +253,9 @@ By default, after each assistant message. Add `"refreshInterval": 10` to your st
 
 **Can I use a single-line layout?**
 Yes — use the `focus` theme: `claude-status --install --theme focus`. It shows only the essentials on one line.
+
+**Why is only Line 1 showing / Line 2 is missing?**
+This is a known Claude Code rendering limitation where long Line 1 output causes Line 2 to be silently dropped. We've optimized the default layout to keep Line 1 short, but if you still see this, try the `focus` theme (`claude-status --install --theme focus`) for a guaranteed single-line display, or widen your terminal to 130+ columns.
 
 **Does it add any latency to Claude Code?**
 No. It runs as a pure stdin-to-stdout pipe in single-digit milliseconds. No daemon, no network calls, no background processes.

--- a/claude_statusline/__init__.py
+++ b/claude_statusline/__init__.py
@@ -1,3 +1,3 @@
 """claude-status: Beautiful status line for Claude Code."""
 
-__version__ = "0.4.1"
+__version__ = "0.4.2"

--- a/claude_statusline/themes.py
+++ b/claude_statusline/themes.py
@@ -15,14 +15,13 @@ THEMES = {
         "bar_left": "[",
         "bar_right": "]",
         "line1": [
-            "bar", "tokens", "cache", "cost", "budget", "burn",
-            "rate_limits", "context_size", "ctx_warning",
+            "bar", "tokens", "cache", "cost", "budget", "burn", "ctx_warning",
         ],
         "line2": [
-            "duration", "latency", "lines", "branch", "git_extras",
-            "tools", "sessions", "session_name", "vim", "agent", "worktree",
-            "model", "output_style", "added_dirs", "git_worktree", "effort",
-            "version", "cc_version", "clock",
+            "rate_limits", "context_size", "duration", "latency", "lines",
+            "branch", "git_extras", "tools", "sessions", "session_name",
+            "vim", "agent", "worktree", "model", "output_style", "added_dirs",
+            "git_worktree", "effort", "version", "cc_version", "clock",
         ],
         "colors": {
             "separator": colors.BRIGHT_BLACK,
@@ -112,14 +111,13 @@ THEMES = {
         "bar_left": "",
         "bar_right": "",
         "line1": [
-            "bar", "tokens", "cache", "cost", "budget", "burn",
-            "rate_limits", "context_size", "ctx_warning",
+            "bar", "tokens", "cache", "cost", "budget", "burn", "ctx_warning",
         ],
         "line2": [
-            "duration", "latency", "lines", "branch", "git_extras",
-            "tools", "sessions", "session_name", "vim", "agent", "worktree",
-            "model", "output_style", "added_dirs", "git_worktree", "effort",
-            "version", "cc_version", "clock",
+            "rate_limits", "context_size", "duration", "latency", "lines",
+            "branch", "git_extras", "tools", "sessions", "session_name",
+            "vim", "agent", "worktree", "model", "output_style", "added_dirs",
+            "git_worktree", "effort", "version", "cc_version", "clock",
         ],
         "colors": {
             "separator": colors.BRIGHT_BLACK,
@@ -161,14 +159,13 @@ THEMES = {
         "bar_left": "[",
         "bar_right": "]",
         "line1": [
-            "bar", "tokens", "cache", "cost", "budget", "burn",
-            "rate_limits", "context_size", "ctx_warning",
+            "bar", "tokens", "cache", "cost", "budget", "burn", "ctx_warning",
         ],
         "line2": [
-            "duration", "latency", "lines", "branch", "git_extras",
-            "tools", "sessions", "session_name", "vim", "agent", "worktree",
-            "model", "output_style", "added_dirs", "git_worktree", "effort",
-            "version", "cc_version", "clock",
+            "rate_limits", "context_size", "duration", "latency", "lines",
+            "branch", "git_extras", "tools", "sessions", "session_name",
+            "vim", "agent", "worktree", "model", "output_style", "added_dirs",
+            "git_worktree", "effort", "version", "cc_version", "clock",
         ],
         "colors": {
             "separator": colors.BRIGHT_BLACK,
@@ -210,14 +207,13 @@ THEMES = {
         "bar_left": "[",
         "bar_right": "]",
         "line1": [
-            "bar", "tokens", "cache", "cost", "budget", "burn",
-            "rate_limits", "context_size", "ctx_warning",
+            "bar", "tokens", "cache", "cost", "budget", "burn", "ctx_warning",
         ],
         "line2": [
-            "duration", "latency", "lines", "branch", "git_extras",
-            "tools", "sessions", "session_name", "vim", "agent", "worktree",
-            "model", "output_style", "added_dirs", "git_worktree", "effort",
-            "version", "cc_version", "clock",
+            "rate_limits", "context_size", "duration", "latency", "lines",
+            "branch", "git_extras", "tools", "sessions", "session_name",
+            "vim", "agent", "worktree", "model", "output_style", "added_dirs",
+            "git_worktree", "effort", "version", "cc_version", "clock",
         ],
         "colors": {
             "separator": colors.BRIGHT_BLACK,
@@ -259,14 +255,13 @@ THEMES = {
         "bar_left": "[",
         "bar_right": "]",
         "line1": [
-            "bar", "tokens", "cache", "cost", "budget", "burn",
-            "rate_limits", "context_size", "ctx_warning",
+            "bar", "tokens", "cache", "cost", "budget", "burn", "ctx_warning",
         ],
         "line2": [
-            "duration", "latency", "lines", "branch", "git_extras",
-            "tools", "sessions", "session_name", "vim", "agent", "worktree",
-            "model", "output_style", "added_dirs", "git_worktree", "effort",
-            "version", "cc_version", "clock",
+            "rate_limits", "context_size", "duration", "latency", "lines",
+            "branch", "git_extras", "tools", "sessions", "session_name",
+            "vim", "agent", "worktree", "model", "output_style", "added_dirs",
+            "git_worktree", "effort", "version", "cc_version", "clock",
         ],
         "colors": {
             "separator": colors.BRIGHT_BLACK,
@@ -308,14 +303,13 @@ THEMES = {
         "bar_left": "[",
         "bar_right": "]",
         "line1": [
-            "bar", "tokens", "cache", "cost", "budget", "burn",
-            "rate_limits", "context_size", "ctx_warning",
+            "bar", "tokens", "cache", "cost", "budget", "burn", "ctx_warning",
         ],
         "line2": [
-            "duration", "latency", "lines", "branch", "git_extras",
-            "tools", "sessions", "session_name", "vim", "agent", "worktree",
-            "model", "output_style", "added_dirs", "git_worktree", "effort",
-            "version", "cc_version", "clock",
+            "rate_limits", "context_size", "duration", "latency", "lines",
+            "branch", "git_extras", "tools", "sessions", "session_name",
+            "vim", "agent", "worktree", "model", "output_style", "added_dirs",
+            "git_worktree", "effort", "version", "cc_version", "clock",
         ],
         "colors": {
             "separator": colors.BRIGHT_BLACK,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "claude-status"
-version = "0.4.1"
+version = "0.4.2"
 description = "Beautiful, informative status line for Claude Code — zero dependencies, cross-platform"
 readme = "README.md"
 license = {text = "MIT"}


### PR DESCRIPTION
## Summary

Closes #52. Workaround for anthropics/claude-code#28750.

### Problem
Line 2 of the status line disappears on some terminals because Claude Code's Ink TUI uses `wrap: "truncate"`, which silently drops all lines after Line 1 when it overflows terminal width.

### Fix
Moved `rate_limits` and `context_size` from Line 1 to Line 2 in all 6 full-detail themes. Line 1 now stays under ~90 characters even with high values, preventing the Ink truncation from triggering.

**Before:** Line 1 could reach 120+ chars → Line 2 dropped
**After:** Line 1 stays under ~90 chars → both lines visible

### Updated Layout
```
Line 1:  [████████░░░░░░░░░░░░] │ in:245K out:18K │ cache:41% │ $0.73 │ burn:37K/min
Line 2:  5h:34% 7d:18% ~2h │ (200K) │ 12m05s │ +247 -38 │ ⎇ myapp/feat/statusline │ v0.4.2 │ 15:30
```

### Also
- README FAQ documents the limitation with workarounds
- Upstream tracking issue created (#53)

### Stats
- 210 tests passing
- Zero dependencies

## Test plan
- [x] All 210 tests pass
- [x] Line 1 under 90 chars with high values (verified with $225 cost, 92% context)
- [x] Line 2 renders with rate limits, context size, duration, branch
- [x] No secrets, no AI attribution
- [x] Code review: zero issues