### PR TITLE
fix: !CTX warning no longer falsely triggers on 1M context windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.3] - 2026-04-11
+
+### Fixed
+- **!CTX warning showing at low context usage on 1M windows** — the `exceeds_200k_tokens` flag is a fixed 200K threshold that fires at ~20% usage on 1M context windows. Removed this legacy fallback; `!CTX` now only triggers at 85%+ of actual context window usage via the percentage-based check. Closes #55.
+
 ## [0.4.2] - 2026-04-10
 
 ### Fixed

--- a/claude_statusline/__init__.py
+++ b/claude_statusline/__init__.py
@@ -1,3 +1,3 @@
 """claude-status: Beautiful status line for Claude Code."""
 
-__version__ = "0.4.2"
+__version__ = "0.4.3"

--- a/claude_statusline/cli.py
+++ b/claude_statusline/cli.py
@@ -100,9 +100,6 @@ def _normalize(data):
     out["lines_added"] = _first(cost_obj.get("total_lines_added"), data.get("lines_added"))
     out["lines_removed"] = _first(cost_obj.get("total_lines_removed"), data.get("lines_removed"))
 
-    # Booleans
-    out["exceeds_200k"] = data.get("exceeds_200k_tokens", False)
-
     # Vim (nested or flat)
     vim_obj = data.get("vim") or {}
     out["vim_mode"] = vim_obj.get("mode") or data.get("vim_mode")

--- a/claude_statusline/cli.py
+++ b/claude_statusline/cli.py
@@ -577,9 +577,8 @@ def cmd_demo():
             _print_indented(render(data, name))
             print()
 
-        # Also show warning state
+        # Also show warning state (93% triggers !CTX via percentage check)
         warn_data = json.loads(json.dumps(data))
-        warn_data["exceeds_200k_tokens"] = True
         warn_data["context_window"]["used_percentage"] = 93
         print("  warning state (93% usage):")
         _print_indented(render(warn_data, "default"))

--- a/claude_statusline/cli.py
+++ b/claude_statusline/cli.py
@@ -274,9 +274,8 @@ def _render_sections(n, order, theme):
             sections.append(colorize("({})".format(label), BRIGHT_BLACK))
 
         elif section == "ctx_warning":
-            # Prefer percentage-based warning (works for any context window size)
-            # Fall back to exceeds_200k_tokens for backward compatibility
-            if (pct is not None and pct >= CTX_WARNING_THRESHOLD_PCT) or exceeds_200k:
+            # Percentage-based warning — works for any context window size
+            if pct is not None and pct >= CTX_WARNING_THRESHOLD_PCT:
                 sections.append(colorize("!CTX", BRIGHT_RED, BOLD))
 
         elif section == "vim" and vim_mode:

--- a/claude_statusline/cli.py
+++ b/claude_statusline/cli.py
@@ -195,7 +195,6 @@ def _render_sections(n, order, theme):
     lines_added = n["lines_added"]
     lines_removed = n["lines_removed"]
     context_size = n["context_size"]
-    exceeds_200k = n["exceeds_200k"]
     vim_mode = n["vim_mode"]
     agent_name = n["agent_name"]
     worktree_branch = n["worktree_branch"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "claude-status"
-version = "0.4.2"
+version = "0.4.3"
 description = "Beautiful, informative status line for Claude Code — zero dependencies, cross-platform"
 readme = "README.md"
 license = {text = "MIT"}

--- a/tests/test_all.py
+++ b/tests/test_all.py
@@ -389,6 +389,14 @@ class TestRender(unittest.TestCase):
         result = render(data)
         self.assertNotIn("!CTX", result)
 
+    def test_ctx_warning_no_pct_with_exceeds_200k(self):
+        """Missing used_percentage + exceeds_200k should NOT warn."""
+        data = self._full_data()
+        data["exceeds_200k_tokens"] = True
+        del data["context_window"]["used_percentage"]
+        result = render(data)
+        self.assertNotIn("!CTX", result)
+
     def test_vim_mode(self):
         data = self._full_data()
         data["vim"] = {"mode": "NORMAL"}

--- a/tests/test_all.py
+++ b/tests/test_all.py
@@ -342,11 +342,17 @@ class TestRender(unittest.TestCase):
         result = render({"context_window": None})
         self.assertIsInstance(result, str)
 
-    def test_exceeds_200k(self):
+    def test_exceeds_200k_no_warning_if_below_85pct(self):
+        """exceeds_200k_tokens alone should NOT trigger !CTX warning.
+
+        The percentage-based check is the only warning trigger now.
+        On 1M context windows, exceeding 200K tokens is only ~20% usage.
+        """
         data = self._full_data()
         data["exceeds_200k_tokens"] = True
+        data["context_window"]["used_percentage"] = 42  # well below 85%
         result = render(data)
-        self.assertIn("!CTX", result)
+        self.assertNotIn("!CTX", result)
 
     def test_ctx_warning_at_85_percent(self):
         """Warning should trigger at 85%+ usage regardless of context size."""
@@ -370,6 +376,15 @@ class TestRender(unittest.TestCase):
         data = self._full_data()
         data["exceeds_200k_tokens"] = False
         data["context_window"]["used_percentage"] = 20
+        data["context_window"]["context_window_size"] = 1_000_000
+        result = render(data)
+        self.assertNotIn("!CTX", result)
+
+    def test_ctx_warning_1m_exceeds_200k_low_pct(self):
+        """1M context exceeding 200K tokens but at 25% should NOT warn."""
+        data = self._full_data()
+        data["exceeds_200k_tokens"] = True
+        data["context_window"]["used_percentage"] = 25
         data["context_window"]["context_window_size"] = 1_000_000
         result = render(data)
         self.assertNotIn("!CTX", result)


### PR DESCRIPTION
## Summary

Closes #55.

### Problem
On 1M context windows, `!CTX` warning showed at ~20% usage because `exceeds_200k_tokens` is a fixed 200K threshold — meaningless on 1M windows.

### Fix
Removed the `exceeds_200k_tokens` fallback. `!CTX` now only triggers at 85%+ of actual context window usage via the percentage-based check. Works correctly for both 200K and 1M windows.

### Also cleaned up
- Removed dead `exceeds_200k` variable (no longer consumed)
- Removed vestigial `exceeds_200k_tokens = True` from demo warning state
- Added edge case test: missing `used_percentage` + `exceeds_200k = True` should NOT warn

### Stats
- 212 tests passing (2 new)
- Zero dependencies

## Test plan

- [x] All 212 tests pass
- [x] 1M context at 25% with exceeds_200k=True does NOT show !CTX
- [x] Missing pct + exceeds_200k=True does NOT show !CTX
- [x] 85%+ usage still correctly shows !CTX
- [x] No dead code remaining
- [x] No secrets, no AI attribution
- [x] 3 review agents passed after fixes