### PR TITLE
fix: move burn to Line 2 — Line 1 overflow causing Line 2 to disappear

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.1] - 2026-04-12
+
+### Fixed
+- **Line 2 still disappearing** — moved `burn` from Line 1 to Line 2, reducing Line 1 visible width to ~55 chars max. With high cost values ($1179+), Line 1 was reaching 121 visible chars, triggering the Ink truncation at 120 cols. Closes #66.
+
 ## [0.5.0] - 2026-04-11
 
 ### Added

--- a/claude_statusline/__init__.py
+++ b/claude_statusline/__init__.py
@@ -1,3 +1,3 @@
 """claude-status: Beautiful status line for Claude Code."""
 
-__version__ = "0.5.0"
+__version__ = "0.5.1"

--- a/claude_statusline/themes.py
+++ b/claude_statusline/themes.py
@@ -15,10 +15,10 @@ THEMES = {
         "bar_left": "[",
         "bar_right": "]",
         "line1": [
-            "bar", "tokens", "cache", "cost", "budget", "burn", "ctx_warning",
+            "bar", "tokens", "cache", "cost", "budget", "ctx_warning",
         ],
         "line2": [
-            "rate_limits", "context_size", "duration", "latency", "speed",
+            "burn", "rate_limits", "context_size", "duration", "latency", "speed",
             "lines", "branch", "git_extras", "git_state", "commit_age",
             "tools", "sessions", "session_name",
             "vim", "agent", "worktree", "model", "output_style", "added_dirs",
@@ -120,10 +120,10 @@ THEMES = {
         "bar_left": "",
         "bar_right": "",
         "line1": [
-            "bar", "tokens", "cache", "cost", "budget", "burn", "ctx_warning",
+            "bar", "tokens", "cache", "cost", "budget", "ctx_warning",
         ],
         "line2": [
-            "rate_limits", "context_size", "duration", "latency", "speed",
+            "burn", "rate_limits", "context_size", "duration", "latency", "speed",
             "lines", "branch", "git_extras", "git_state", "commit_age",
             "tools", "sessions", "session_name",
             "vim", "agent", "worktree", "model", "output_style", "added_dirs",
@@ -173,10 +173,10 @@ THEMES = {
         "bar_left": "[",
         "bar_right": "]",
         "line1": [
-            "bar", "tokens", "cache", "cost", "budget", "burn", "ctx_warning",
+            "bar", "tokens", "cache", "cost", "budget", "ctx_warning",
         ],
         "line2": [
-            "rate_limits", "context_size", "duration", "latency", "speed",
+            "burn", "rate_limits", "context_size", "duration", "latency", "speed",
             "lines", "branch", "git_extras", "git_state", "commit_age",
             "tools", "sessions", "session_name",
             "vim", "agent", "worktree", "model", "output_style", "added_dirs",
@@ -226,10 +226,10 @@ THEMES = {
         "bar_left": "[",
         "bar_right": "]",
         "line1": [
-            "bar", "tokens", "cache", "cost", "budget", "burn", "ctx_warning",
+            "bar", "tokens", "cache", "cost", "budget", "ctx_warning",
         ],
         "line2": [
-            "rate_limits", "context_size", "duration", "latency", "speed",
+            "burn", "rate_limits", "context_size", "duration", "latency", "speed",
             "lines", "branch", "git_extras", "git_state", "commit_age",
             "tools", "sessions", "session_name",
             "vim", "agent", "worktree", "model", "output_style", "added_dirs",
@@ -279,10 +279,10 @@ THEMES = {
         "bar_left": "[",
         "bar_right": "]",
         "line1": [
-            "bar", "tokens", "cache", "cost", "budget", "burn", "ctx_warning",
+            "bar", "tokens", "cache", "cost", "budget", "ctx_warning",
         ],
         "line2": [
-            "rate_limits", "context_size", "duration", "latency", "speed",
+            "burn", "rate_limits", "context_size", "duration", "latency", "speed",
             "lines", "branch", "git_extras", "git_state", "commit_age",
             "tools", "sessions", "session_name",
             "vim", "agent", "worktree", "model", "output_style", "added_dirs",
@@ -332,10 +332,10 @@ THEMES = {
         "bar_left": "[",
         "bar_right": "]",
         "line1": [
-            "bar", "tokens", "cache", "cost", "budget", "burn", "ctx_warning",
+            "bar", "tokens", "cache", "cost", "budget", "ctx_warning",
         ],
         "line2": [
-            "rate_limits", "context_size", "duration", "latency", "speed",
+            "burn", "rate_limits", "context_size", "duration", "latency", "speed",
             "lines", "branch", "git_extras", "git_state", "commit_age",
             "tools", "sessions", "session_name",
             "vim", "agent", "worktree", "model", "output_style", "added_dirs",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "claude-status"
-version = "0.5.0"
+version = "0.5.1"
 description = "Beautiful, informative status line for Claude Code — zero dependencies, cross-platform"
 readme = "README.md"
 license = {text = "MIT"}


### PR DESCRIPTION
## Summary

Closes #66. Further workaround for anthropics/claude-code#28750.

Line 1 with high cost values ($1179+) was reaching 121 visible chars at 120-col terminals, triggering the Ink truncation that drops Line 2.

### Fix
Moved `burn` from Line 1 to Line 2 in all 6 full-detail themes. Line 1 now maxes at ~55 visible chars.

**Line 1 before:** bar + tokens + cache + cost + budget + burn + warning (~121 chars with high values)
**Line 1 after:** bar + tokens + cache + cost + budget + warning (~55 chars max)

242 tests, zero regressions.