### PR TITLE
feat: v0.5.4 — width-aware adaptive layout (recover sections in mid-width terminals)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -30,10 +30,11 @@ claude_statusline/
 
 1. **`main()`** reads JSON from stdin
 2. **`_normalize(data)`** flattens the nested Claude Code JSON into a flat dict, handling both old and new schema formats
-3. **`_apply_responsive(sections, term_width)`** filters sections based on terminal width (120+/80-119/<80 cols)
-4. **`_render_sections(normalized, order, theme)`** renders each section name into a colored string
-5. **`render(data, theme_name)`** joins sections with themed separators into 1-2 lines
-6. Output is printed to stdout
+3. **`_apply_responsive(sections, term_width)`** coarse pre-filter — filters sections based on terminal width buckets (150+/100-149/<100 cols), skipping the heaviest sections on terminals where they won't fit
+4. **`_render_sections_named(normalized, order, theme)`** renders each section name into a `(name, rendered_string)` pair (skipping sections whose data is absent)
+5. **`_fit_to_width(items, sep_width, term_width, drop_priority)`** precise post-render fit — measures actual visible width (stripping ANSI/OSC 8) and drops sections in priority order until the line fits the terminal
+6. **`render(data, theme_name)`** orchestrates steps 2–5 and joins surviving sections with themed separators into 1-2 lines
+7. Output is printed to stdout
 
 ### Section Rendering
 
@@ -73,11 +74,17 @@ Cache files are:
 
 ### Responsive Layout
 
-Sections are dropped progressively based on terminal width:
+Two-stage adaptation prevents Line 2 truncation under Claude Code's `wrap:"truncate"` Ink behavior (anthropics/claude-code#28750) while still showing as much detail as the terminal can hold.
 
-- **120+ cols**: Full layout (all sections)
-- **80-119 cols**: Compact (drops git_extras, version, cc_version, clock, worktree, sessions, tools, latency, context_size, session_name, rate_limits, output_style, added_dirs, effort, git_worktree)
-- **<80 cols**: Narrow (additionally drops cache, burn, lines, budget, agent, model)
+**Stage 1 — coarse pre-filter** (`_apply_responsive`) picks an eligible section list by terminal-width bucket. Sections in `_COMPACT_DROP` are skipped before rendering on terminals where they won't fit, avoiding the cost of git subprocess calls and file scans on narrow terminals:
+
+- **150+ cols**: Full layout (all sections eligible)
+- **100-149 cols**: Compact (drops git_extras, version, cc_version, clock, worktree, sessions, tools, latency, context_size, session_name, rate_limits, output_style, added_dirs, effort, git_worktree, speed, git_state, commit_age)
+- **<100 cols**: Narrow (additionally drops cache, burn, lines, budget, agent, model)
+
+**Stage 2 — precise width-aware fit** (`_fit_to_width`) measures the actual rendered width of each line (stripping invisible ANSI SGR + OSC 8 escapes) and drops sections in `_FIT_DROP_PRIORITY` order — one at a time — until the line fits the terminal. `_FIT_DROP_PRIORITY` extends `_COMPACT_DROP` with last-resort drops (vim, agent, lines, duration, burn, model, cache, budget) so the precise stage can always reach a fitting result, even in the compact band with heavy data.
+
+Truly essential sections (bar, tokens, cost, branch, ctx_warning) are deliberately omitted from `_FIT_DROP_PRIORITY` and never dropped — losing those would defeat the statusline's purpose.
 
 ## Themes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,24 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.4] - 2026-04-16
+
+### Added
+- **Width-aware adaptive layout** — render() now performs a precise post-render fit on each line: it measures actual visible width (stripping ANSI/OSC 8 escapes) and drops sections in priority order one at a time until the line fits the terminal. This recovers sections like `rate_limits`, `speed`, `version`, `clock`, `commit_age`, etc. on terminals between the compact band and full layout where the v0.5.3 compact bucket would have hidden them all unconditionally.
+- New tests cover ANSI/OSC 8 stripping (including BEL-terminated OSC 8 used by Kitty/Screen), the priority-based drop algorithm, end-to-end width fit, and recovery (rate_limits visible at 180 cols, dropped at 120 cols).
+
+### Changed
+- Lowered the full-layout pre-filter threshold from 230 → 150 cols. Above 150, all sections are eligible and the precise stage trims as needed. Below 150, the coarse pre-filter still skips the heaviest sections (git subprocess calls, file scans for tools/sessions) so we don't pay rendering cost on terminals where they won't fit.
+- Two-stage layout: coarse pre-filter (`_apply_responsive`) picks an eligible section list by terminal-width bucket, then precise fit (`_fit_to_width`) trims after rendering. The precise stage uses `_FIT_DROP_PRIORITY`, which extends `_COMPACT_DROP` with last-resort drops (vim, agent, lines, duration, burn, model, cache, budget) so the compact band (100-149 cols) can also reach a fitting result with heavy data.
+- `--doctor` now reports the actual layout thresholds (driven by the constants) instead of hardcoded values that drifted in v0.5.3 → v0.5.4.
+
+### Fixed
+- OSC 8 hyperlink regex now matches both string-terminator forms (ST `\x1b\\` and BEL `\x07`) so width measurement stays accurate when text passes through emitters that use BEL.
+
+### Notes
+- Anthropic's underlying `wrap:"truncate"` bug (anthropics/claude-code#28750) remains unaddressed upstream — the issue was closed by stalebot after 30 days of inactivity following the reporter's root-cause trace. Our two-stage layout makes the workaround tighter: instead of dropping the entire compact-bucket of sections at a single width threshold, we measure and drop only what actually doesn't fit.
+- Users who previously saw a sparse Line 2 between the compact and full thresholds will see additional sections automatically. No config change required.
+
 ## [0.5.3] - 2026-04-13
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Notes
 - Anthropic's underlying `wrap:"truncate"` bug (anthropics/claude-code#28750) remains unaddressed upstream — the issue was closed by stalebot after 30 days of inactivity following the reporter's root-cause trace. Our two-stage layout makes the workaround tighter: instead of dropping the entire compact-bucket of sections at a single width threshold, we measure and drop only what actually doesn't fit.
 - Users who previously saw a sparse Line 2 between the compact and full thresholds will see additional sections automatically. No config change required.
+- Closes #73.
 
 ## [0.5.3] - 2026-04-13
 

--- a/README.md
+++ b/README.md
@@ -202,12 +202,18 @@ This runs the status line every 10 seconds in addition to the standard update tr
 
 ## Responsive Layout
 
-The status line automatically adapts to your terminal width:
-- **230+ columns**: full detail (all sections)
-- **100–229 columns**: compact (drops git_extras, version, clock, rate_limits, speed, commit_age, session_name, cc_version, etc.)
-- **Under 100 columns**: narrow (essentials only — bar, tokens, cost, duration, branch)
+The status line automatically adapts to your terminal width via a two-stage process:
 
-The full-layout threshold is 230 rather than 120 because Line 2 can reach ~225 visible characters with a worst-case realistic payload (long session, long branch/session name, all rate limits populated) as features were added in v0.3-v0.5. A 120-col terminal with all sections populated would cause Claude Code's Ink TUI to truncate Line 2 with an ellipsis. Most terminals will land in the compact layout — the safe default. If you want the full detail, widen your terminal to 230+ columns.
+1. **Coarse pre-filter** picks an eligible section list by terminal width:
+   - **150+ columns**: full layout (all sections eligible)
+   - **100–149 columns**: compact (drops the heaviest extras up front so we don't pay rendering cost on terminals where they won't fit)
+   - **Under 100 columns**: narrow (essentials only — bar, tokens, cost, duration, branch)
+
+2. **Precise width-aware fit** then measures the actual rendered width of each line (stripping invisible ANSI/OSC 8 escapes) and drops sections in priority order until the line fits the terminal. This means a 180-col terminal sees rate_limits, speed, version, etc., even though the static compact bucket would have hidden them — and a 110-col terminal stays within bounds even with heavy data (long agent name, vim mode active, long branch + session name).
+
+The bar, tokens, cost, branch, and `!CTX` warning are always preserved — even at extreme widths, the statusline keeps its core identity.
+
+This design exists because Claude Code's TUI uses Ink `<Text wrap="truncate">` on the statusline (anthropics/claude-code#28750, still unaddressed upstream): if Line 1 overflows the terminal, Line 2 is silently dropped. Measuring our actual rendered width and dropping low-priority sections one at a time prevents this without sacrificing useful information on wider terminals.
 
 ## Manual Configuration
 
@@ -263,13 +269,13 @@ By default, after each assistant message. Add `"refreshInterval": 10` to your st
 Yes — use the `focus` theme: `claude-status --install --theme focus`. It shows only the essentials on one line.
 
 **Why is only Line 1 showing / Line 2 is missing or truncated?**
-Claude Code's TUI uses Ink `<Text wrap="truncate">` which silently drops or truncates lines that exceed the terminal width. Three things can trigger this, all fixed:
+Claude Code's TUI uses Ink `<Text wrap="truncate">` which silently drops or truncates lines that exceed the terminal width. Several things can trigger this, all fixed:
 
 1. **Line 1 visibly overflows** — fixed in v0.4.2 and v0.5.1 by moving sections to Line 2.
 2. **OSC 8 clickable links add invisible escape bytes** — fixed in v0.5.2 by disabling OSC 8 by default.
-3. **Line 2 reaches ~225 chars at worst-case heavy data** — fixed in v0.5.3 by raising the full-layout threshold from 120 to 230 cols. Most terminals now land in compact layout, which guarantees Line 2 fits.
+3. **Line 2 grows past terminal width with heavy data** — fixed in v0.5.4 with a width-aware adaptive layout that measures actual rendered width and drops low-priority sections one at a time until each line fits. The full-layout threshold is now 150 cols (down from 230 in v0.5.3), and the precise post-render fit handles overflow gracefully across the entire range.
 
-Upgrade to the latest release (`pip install -U claude-status`). If you want the full layout, widen your terminal to 230+ columns, or switch to the `focus` theme (`claude-status --install --theme focus`) for a guaranteed single-line display. Tracked upstream at anthropics/claude-code#28750 (closed NOT_PLANNED).
+Upgrade to the latest release (`pip install -U claude-status`). The status line auto-adapts to your terminal width — no configuration needed. If you want a single-line display regardless of width, switch to the `focus` theme (`claude-status --install --theme focus`). Tracked upstream at anthropics/claude-code#28750 (closed without a fix after 30 days of inactivity).
 
 **Does it add any latency to Claude Code?**
 No. It runs as a pure stdin-to-stdout pipe in single-digit milliseconds. No daemon, no network calls, no background processes.

--- a/claude_statusline/__init__.py
+++ b/claude_statusline/__init__.py
@@ -1,3 +1,3 @@
 """claude-status: Beautiful status line for Claude Code."""
 
-__version__ = "0.5.3"
+__version__ = "0.5.4"

--- a/claude_statusline/cli.py
+++ b/claude_statusline/cli.py
@@ -4,6 +4,7 @@ import argparse
 import json
 import os
 import platform
+import re
 import shutil
 import sys
 import tempfile
@@ -204,9 +205,42 @@ def _render_sections(n, order, theme):
         theme: Theme dict.
 
     Returns:
-        List of rendered section strings.
+        List of rendered section strings (rendered text only). Skips
+        sections whose data is absent. Use _render_sections_named()
+        when the caller needs to know which name produced each string
+        (e.g. for width-aware fitting).
     """
-    sections = []
+    return [r for _, r in _render_sections_named(n, order, theme)]
+
+
+def _render_sections_named(n, order, theme):
+    """Render sections, returning (name, rendered) pairs.
+
+    Same logic as _render_sections() but preserves the section name
+    alongside each rendered string. Used by render() to drive
+    _fit_to_width(), which needs to know which sections it can drop.
+    """
+    # `_NamedAppender` lets the existing `sections.append(...)` calls below
+    # remain unchanged while transparently pairing each appended string with
+    # the current section name. Avoids a wide-touch refactor of every append
+    # site in this function. The guard in `append` prevents items being
+    # silently tagged with `None` if a future change moves an append outside
+    # the loop — `None`-tagged items are undroppable by _fit_to_width and
+    # would silently overflow the line.
+    class _NamedAppender:
+        __slots__ = ("items", "current")
+        def __init__(self):
+            self.items = []
+            self.current = None
+        def append(self, value):
+            if self.current is None:
+                raise RuntimeError(
+                    "_NamedAppender.append called without a current section "
+                    "name — every append must follow `sections.current = section`"
+                )
+            self.items.append((self.current, value))
+
+    sections = _NamedAppender()
     tc = theme["colors"]
 
     input_tokens = n["input_tokens"]
@@ -229,6 +263,7 @@ def _render_sections(n, order, theme):
     total_tokens = (input_tokens or 0) + (output_tokens or 0) + (cache_read or 0) + (cache_create or 0)
 
     for section in order:
+        sections.current = section
         if section == "bar" and pct is not None:
             compaction = get_compaction_threshold()
             bar_width = theme.get("bar_width", 20)
@@ -494,23 +529,27 @@ def _render_sections(n, order, theme):
                 if parts:
                     sections.append(" ".join(parts))
 
-    return sections
+    return sections.items
 
 
 # Responsive layout breakpoints (in terminal columns).
 #
-# History: these thresholds were originally 120/80 when Line 2 had ~8
-# sections. As features were added through v0.3–v0.5 (rate limits,
-# speed, git_state, commit_age, session_name, output_style, added_dirs,
-# git_worktree, effort, cc_version), Line 2's full-layout content can
-# reach ~225 visible chars with a worst-case realistic payload (long
-# session, long branch/session name, all rate limits, heavy git state)
-# — overflowing the old 120-col threshold and triggering Claude Code's
-# Ink truncation on Line 2. Raised to 230/100 in v0.5.3 (#70): 230
-# includes a small buffer above the measured worst-case 225 so a
-# terminal exactly at the threshold still fits. Most terminals will
-# land in the compact layout, which is the safe default.
-_FULL_LAYOUT_MIN_COLS = 230
+# These are the COARSE pre-filter thresholds — render() applies a
+# precise width-aware fit (_fit_to_width) on top of this, dropping
+# low-priority sections one at a time until each line fits the actual
+# terminal width.
+#
+# History: thresholds were originally 120/80, then raised to 230/100
+# in v0.5.3 (#70) because Line 2 could reach ~225 visible chars in the
+# worst case and Claude Code's Ink TUI truncates Line 2 when Line 1
+# overflows. The 230 threshold was overly conservative — it meant
+# almost every real terminal (120-200 cols) lost ~19 sections at once.
+# Lowered to 150/100 once the precise stage was added: above 150 cols,
+# all sections are eligible and the precise stage trims as needed.
+# Below 150 we still pre-filter the heaviest sections so we don't pay
+# the cost of rendering them (git subprocess calls, file scans for
+# tools/sessions, etc.) on terminals where they'll never fit anyway.
+_FULL_LAYOUT_MIN_COLS = 150
 _COMPACT_LAYOUT_MIN_COLS = 100
 
 # Sections to drop at each width breakpoint (widest first).
@@ -525,13 +564,39 @@ _NARROW_DROP = _COMPACT_DROP + [
     "cache", "burn", "lines", "budget", "agent", "model",
 ]
 
+# Drop priority for the precise post-render fit (_fit_to_width).
+# Earlier entries are dropped first. Extends _COMPACT_DROP with last-resort
+# drops so the precise stage can always reach a fitting result even when
+# the coarse pre-filter has already kept the compact subset. Sections NOT
+# listed here (bar, tokens, cost, branch, ctx_warning) are truly essential
+# and never dropped — every line keeps the bar+tokens+cost identity even
+# at extreme widths.
+#
+# Ordering rationale: extras first (same as _COMPACT_DROP), then visual
+# decorations (vim, agent), then sections that carry derived/recomputable
+# info (lines, burn, duration are derivable from cost+tokens), then model
+# (still useful but visible elsewhere in Claude Code's UI), then cache
+# (a percentage that changes slowly), and finally budget (the one section
+# users explicitly opted into via config — drop only if truly nothing else
+# fits). bar/tokens/cost/branch/ctx_warning are deliberately omitted —
+# losing those would defeat the statusline's purpose.
+_FIT_DROP_PRIORITY = _COMPACT_DROP + [
+    "vim", "agent", "worktree", "lines", "duration", "burn",
+    "model", "cache", "budget",
+]
+
 
 def _apply_responsive(sections_list, term_width):
     """Filter section list based on terminal width.
 
-    >= 230 cols: full layout (no changes)
-    100-229 cols: compact (drop non-essential extras)
-    < 100 cols:   narrow (essentials only)
+    >= 150 cols: full layout (no changes)
+    100-149 cols: compact (drop non-essential extras)
+    < 100 cols:  narrow (essentials only)
+
+    Coarse pre-filter only — the precise fit is performed by
+    _fit_to_width() after sections are rendered, so a user at any
+    width above the narrow band can see additional sections when
+    their actual rendered width allows.
     """
     if term_width >= _FULL_LAYOUT_MIN_COLS:
         return sections_list
@@ -544,22 +609,93 @@ def _apply_responsive(sections_list, term_width):
     return [s for s in sections_list if s not in drop]
 
 
+# Match SGR escapes (\x1b[…m) and OSC 8 hyperlink wrappers. OSC 8 has
+# two valid string terminators per the ECMA-48 spec: ST (\x1b\\) and
+# BEL (\x07). Several emitters (Kitty, GNU Screen wrappers, some Vim
+# plugins) use BEL, so we must match both — otherwise BEL-form links
+# count as visible bytes and _fit_to_width over-drops sections.
+# Both SGR and OSC 8 contribute zero visible width but inflate raw
+# byte length.
+_ANSI_SGR_RE = re.compile(r"\x1b\[[0-9;]*m")
+_OSC8_RE = re.compile(r"\x1b\]8;;[^\x07\x1b]*(?:\x07|\x1b\\)")
+
+
+def _visible_width(s):
+    """Visible character width of a string after stripping ANSI + OSC 8.
+
+    Approximation: counts each remaining code point as width 1. Wide
+    East-Asian characters and emoji are over-counted as 1 instead of 2,
+    but our statusline glyphs (\u2387 for branch, \u2726 for session,
+    bar blocks, etc.) are all single-width — so this matches reality
+    for our content. The unicodedata.east_asian_width path is omitted
+    intentionally to keep zero dependencies and stay deterministic.
+    """
+    s = _OSC8_RE.sub("", s)
+    s = _ANSI_SGR_RE.sub("", s)
+    return len(s)
+
+
+def _fit_to_width(named_items, sep_visible_width, target_width, drop_priority):
+    """Drop low-priority sections until the joined output fits target_width.
+
+    Args:
+        named_items: List of (name, rendered) tuples from
+            _render_sections_named().
+        sep_visible_width: Visible width of the separator between sections.
+        target_width: Maximum allowed visible width (terminal columns).
+        drop_priority: Ordered list of section names — earliest entries are
+            dropped first when the line overflows. Sections not listed here
+            are considered essential and are never dropped.
+
+    Returns:
+        New list of (name, rendered) tuples that fit within target_width.
+        Order of surviving sections is preserved.
+    """
+    items = list(named_items)
+
+    def total_width(items):
+        if not items:
+            return 0
+        return sum(_visible_width(r) for _, r in items) + sep_visible_width * (len(items) - 1)
+
+    if total_width(items) <= target_width:
+        return items
+
+    for name in drop_priority:
+        if total_width(items) <= target_width:
+            break
+        items = [(n, r) for (n, r) in items if n != name]
+
+    return items
+
+
 def render(data, theme_name="default"):
     """Render the statusline as one or two lines.
 
-    Automatically adapts layout based on terminal width:
-    - >= 230 cols: full detail (all sections)
-    - 100-229 cols: compact (drops git_extras, version, clock, rate_limits,
-      context_size, speed, commit_age, session_name, cc_version, etc.)
-    - < 100 cols: narrow (essentials only — bar, tokens, cost, duration, branch)
+    Two-stage layout adaptation:
 
-    The full-layout threshold is 230 rather than 120 because Line 2 can
-    reach ~225 visible chars with a worst-case realistic payload (long
-    session, long branch/session name, all rate limits populated) as
-    features were added in v0.3-v0.5. A 120-col terminal with all data
-    populated would cause Claude Code's Ink TUI to truncate Line 2 with
-    an ellipsis. 230 buffers above the measured 225. Most terminals will
-    land in compact layout — the safe default.
+    1. Coarse pre-filter (_apply_responsive) — picks a section list
+       based on terminal width buckets:
+       - >= 150 cols: full layout (all sections eligible)
+       - 100-149 cols: compact (drops the heaviest extras up front
+         so we don't pay rendering cost on terminals where they
+         won't fit)
+       - < 100 cols: narrow (essentials only)
+
+    2. Precise width-aware fit (_fit_to_width) — renders the surviving
+       sections, measures actual visible width (stripping ANSI/OSC 8),
+       and drops sections in _FIT_DROP_PRIORITY order one at a time
+       until each line fits the terminal. This recovers sections like
+       rate_limits, speed, version, etc. on 150-220 col terminals
+       where the static compact bucket would have hidden them
+       unnecessarily — and also handles the compact band (100-149)
+       where the kept sections might still overflow with heavy data
+       (long agent name, vim mode active, long branch+session).
+
+    Stage 2 exists because Claude Code's Ink TUI uses wrap:"truncate"
+    on the statusline (anthropics/claude-code#28750, still unfixed) —
+    if Line 1 overflows, Line 2 is silently dropped. Measuring our
+    actual rendered width and shrinking until we fit prevents this.
 
     Args:
         data: Parsed JSON dict from Claude Code.
@@ -571,6 +707,7 @@ def render(data, theme_name="default"):
     theme = get_theme(theme_name)
     n = _normalize(data)
     sep = colorize(theme["separator"], theme["colors"]["separator"])
+    sep_width = _visible_width(sep)
 
     # Default to compact layout when terminal size cannot be detected
     # (non-interactive contexts, piped stdout, some SSH setups).
@@ -584,14 +721,25 @@ def render(data, theme_name="default"):
         line1 = [s for s in line1 if s not in disabled]
         line2 = [s for s in line2 if s not in disabled]
 
-    line1_sections = _render_sections(n, line1, theme)
-    line2_sections = _render_sections(n, line2, theme)
+    line1_named = _render_sections_named(n, line1, theme)
+    line2_named = _render_sections_named(n, line2, theme)
+
+    # Precise width-aware fit. Drop priority is _FIT_DROP_PRIORITY —
+    # extends _COMPACT_DROP with last-resort drops (vim, agent, lines,
+    # duration, burn, model, cache, budget) so the precise stage can
+    # always reach a fitting result. Without these last-resort entries,
+    # the compact band (100-149 cols) silently overflows because most
+    # surviving line2 sections wouldn't be droppable. Sections not in
+    # this list (bar, tokens, cost, branch, ctx_warning) are truly
+    # essential and never dropped here.
+    line1_named = _fit_to_width(line1_named, sep_width, term_width, _FIT_DROP_PRIORITY)
+    line2_named = _fit_to_width(line2_named, sep_width, term_width, _FIT_DROP_PRIORITY)
 
     lines = []
-    if line1_sections:
-        lines.append(sep.join(line1_sections))
-    if line2_sections:
-        lines.append(sep.join(line2_sections))
+    if line1_named:
+        lines.append(sep.join(r for _, r in line1_named))
+    if line2_named:
+        lines.append(sep.join(r for _, r in line2_named))
 
     return "\n".join(lines)
 
@@ -1034,15 +1182,17 @@ def cmd_doctor():
     # Terminal capabilities
     print("Terminal:")
     term = os.environ.get("TERM", "(not set)")
-    cols = shutil.get_terminal_size((120, 24)).columns
+    cols = shutil.get_terminal_size((_COMPACT_LAYOUT_MIN_COLS, 24)).columns
     print("  TERM:    {}".format(term))
     print("  Columns: {}".format(cols))
-    if cols >= 120:
-        print("  Layout:  full")
-    elif cols >= 80:
-        print("  Layout:  compact")
+    if cols >= _FULL_LAYOUT_MIN_COLS:
+        print("  Layout:  full (>= {} cols)".format(_FULL_LAYOUT_MIN_COLS))
+    elif cols >= _COMPACT_LAYOUT_MIN_COLS:
+        print("  Layout:  compact ({}-{} cols)".format(
+            _COMPACT_LAYOUT_MIN_COLS, _FULL_LAYOUT_MIN_COLS - 1))
     else:
-        print("  Layout:  narrow")
+        print("  Layout:  narrow (< {} cols)".format(_COMPACT_LAYOUT_MIN_COLS))
+    print("  Note:    precise width-aware fit further trims sections to fit")
     print("  Unicode: \u2588\u2591\u2593 \u2387 \ue0b0")
     print()
 

--- a/claude_statusline/cli.py
+++ b/claude_statusline/cli.py
@@ -650,23 +650,44 @@ def _fit_to_width(named_items, sep_visible_width, target_width, drop_priority):
     Returns:
         New list of (name, rendered) tuples that fit within target_width.
         Order of surviving sections is preserved.
+
+    Width math: each visible char counts as 1. Each rendered section is
+    measured once up front, then maintained incrementally as sections
+    are dropped — avoids re-stripping ANSI on every survivor on every
+    drop iteration (suggested by Gemini code review on PR #72).
     """
-    items = list(named_items)
+    if not named_items:
+        return []
 
-    def total_width(items):
-        if not items:
-            return 0
-        return sum(_visible_width(r) for _, r in items) + sep_visible_width * (len(items) - 1)
+    # Pre-compute each section's visible width once so we never re-strip
+    # ANSI on a survivor we've already measured.
+    items = [(name, rendered, _visible_width(rendered))
+             for (name, rendered) in named_items]
+    total = sum(w for _, _, w in items) + sep_visible_width * (len(items) - 1)
 
-    if total_width(items) <= target_width:
-        return items
+    if total <= target_width:
+        return [(n, r) for (n, r, _) in items]
 
-    for name in drop_priority:
-        if total_width(items) <= target_width:
+    for drop_name in drop_priority:
+        if total <= target_width:
             break
-        items = [(n, r) for (n, r) in items if n != name]
+        # Partition by name. Recompute total via:
+        #   total' = (total before) - sum(dropped widths) - (count_dropped) * sep
+        #   then cap so we never count a separator that wasn't there
+        #   (when the survivors list ends up empty or had nothing to
+        #   begin with).
+        kept = [(n, r, w) for (n, r, w) in items if n != drop_name]
+        if len(kept) == len(items):
+            continue  # nothing matched this drop_name
+        dropped_width = sum(w for (n, _, w) in items if n == drop_name)
+        # Separator count change: items had len(items)-1 separators,
+        # kept has max(0, len(kept)-1). Subtract the difference.
+        old_seps = max(0, len(items) - 1)
+        new_seps = max(0, len(kept) - 1)
+        total -= dropped_width + (old_seps - new_seps) * sep_visible_width
+        items = kept
 
-    return items
+    return [(n, r) for (n, r, _) in items]
 
 
 def render(data, theme_name="default"):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "claude-status"
-version = "0.5.3"
+version = "0.5.4"
 description = "Beautiful, informative status line for Claude Code — zero dependencies, cross-platform"
 readme = "README.md"
 license = {text = "MIT"}

--- a/tests/test_all.py
+++ b/tests/test_all.py
@@ -1515,10 +1515,18 @@ class TestResponsiveLayout(unittest.TestCase):
         self.assertNotIn("cache", result)  # cache is in _NARROW_DROP
 
     def test_boundary_at_full_threshold(self):
-        """229 cols (just below full threshold) should use compact layout."""
+        """149 cols (just below full threshold) should use compact layout.
+
+        The full-layout threshold was lowered from 230 → 150 in the
+        width-aware-layout change because a precise post-render fit
+        (_fit_to_width) handles the actual sizing — the coarse
+        pre-filter only needs to skip expensive sections (git
+        subprocess calls, file scans) on terminals where they will
+        never fit.
+        """
         from claude_statusline.cli import _apply_responsive
         sections = ["bar", "tokens", "cost", "git_extras"]
-        result = _apply_responsive(sections, 229)
+        result = _apply_responsive(sections, 149)
         self.assertIn("bar", result)
         self.assertNotIn("git_extras", result)  # compact drops git_extras
 
@@ -1568,6 +1576,189 @@ class TestResponsiveLayout(unittest.TestCase):
         finally:
             if old_cols is not None:
                 os.environ["COLUMNS"] = old_cols
+
+
+# ─── cli.py — width-aware fit ────────────────────────────────────────
+
+class TestVisibleWidth(unittest.TestCase):
+    """_visible_width strips ANSI/OSC 8 — Claude Code's Ink TUI counts
+    visible glyphs only, so our fit math must match that."""
+
+    def test_plain_text_width(self):
+        from claude_statusline.cli import _visible_width
+        self.assertEqual(_visible_width("hello"), 5)
+
+    def test_empty_string(self):
+        from claude_statusline.cli import _visible_width
+        self.assertEqual(_visible_width(""), 0)
+
+    def test_strips_sgr_color(self):
+        from claude_statusline.cli import _visible_width
+        # Red "abc" reset → visible width is 3
+        self.assertEqual(_visible_width("\x1b[31mabc\x1b[0m"), 3)
+
+    def test_strips_multiple_sgr(self):
+        from claude_statusline.cli import _visible_width
+        s = "\x1b[1m\x1b[31mbold red\x1b[0m \x1b[32mgreen\x1b[0m"
+        self.assertEqual(_visible_width(s), len("bold red green"))
+
+    def test_strips_osc8_hyperlink(self):
+        """OSC 8 wrapper bytes are zero-width — only the link text counts."""
+        from claude_statusline.cli import _visible_width
+        s = "\x1b]8;;https://example.com\x1b\\link\x1b]8;;\x1b\\"
+        self.assertEqual(_visible_width(s), len("link"))
+
+    def test_strips_combined_osc8_and_sgr(self):
+        from claude_statusline.cli import _visible_width
+        s = "\x1b]8;;https://x.test\x1b\\\x1b[36mlinked\x1b[0m\x1b]8;;\x1b\\"
+        self.assertEqual(_visible_width(s), len("linked"))
+
+    def test_strips_osc8_with_bel_terminator(self):
+        """OSC 8 also permits BEL (\\x07) as the string terminator (Kitty,
+        GNU Screen wrappers, some Vim plugins). The regex must match
+        both ST and BEL — otherwise BEL-form links inflate the measured
+        width and _fit_to_width over-drops sections."""
+        from claude_statusline.cli import _visible_width
+        s = "\x1b]8;;https://example.com\x07link\x1b]8;;\x07"
+        self.assertEqual(_visible_width(s), len("link"))
+
+    def test_strips_osc8_mixed_terminators(self):
+        """Defensive: opener with ST, closer with BEL (or vice versa) —
+        each wrapper element matches the alternation independently."""
+        from claude_statusline.cli import _visible_width
+        s = "\x1b]8;;https://x\x1b\\link\x1b]8;;\x07"
+        self.assertEqual(_visible_width(s), len("link"))
+
+
+class TestFitToWidth(unittest.TestCase):
+    """_fit_to_width drops sections in priority order until the line fits.
+
+    Sections not in drop_priority are essential and must never be dropped
+    (e.g. bar, tokens, cost, branch). Sections in drop_priority are
+    dropped earliest-first when the line overflows."""
+
+    def test_no_drop_when_fits(self):
+        from claude_statusline.cli import _fit_to_width
+        items = [("bar", "[####]"), ("cost", "$1.20")]
+        result = _fit_to_width(items, sep_visible_width=3, target_width=80,
+                               drop_priority=["clock", "version"])
+        self.assertEqual(result, items)
+
+    def test_drops_lowest_priority_first(self):
+        """When over budget, the earliest entry in drop_priority is dropped."""
+        from claude_statusline.cli import _fit_to_width
+        items = [("bar", "[####]"),       # 6
+                 ("clock", "12:34"),       # 5
+                 ("version", "v0.5.3"),    # 6
+                 ("cost", "$1.20")]        # 5
+        # Total visible chars = 22 + 3 separators of width 3 = 31.
+        # Set target=26 so we must drop one section. drop_priority drops
+        # clock first.
+        result = _fit_to_width(items, sep_visible_width=3, target_width=26,
+                               drop_priority=["clock", "version"])
+        names = [n for n, _ in result]
+        self.assertNotIn("clock", names)
+        self.assertIn("version", names)
+        self.assertIn("bar", names)
+        self.assertIn("cost", names)
+
+    def test_drops_multiple_when_needed(self):
+        from claude_statusline.cli import _fit_to_width
+        items = [("bar", "[####]"),      # 6
+                 ("clock", "12:34"),     # 5
+                 ("version", "v0.5.3"),  # 6
+                 ("cost", "$1.20")]      # 5
+        # Force a tiny target so both droppable sections must go.
+        result = _fit_to_width(items, sep_visible_width=3, target_width=15,
+                               drop_priority=["clock", "version"])
+        names = [n for n, _ in result]
+        self.assertEqual(names, ["bar", "cost"])
+
+    def test_never_drops_essential_sections(self):
+        """Sections not in drop_priority are kept even if line still overflows."""
+        from claude_statusline.cli import _fit_to_width
+        items = [("bar", "[####]"), ("cost", "$1.20")]
+        # Target so small nothing fits, but neither section is droppable.
+        result = _fit_to_width(items, sep_visible_width=3, target_width=2,
+                               drop_priority=["clock", "version"])
+        # Both essentials remain — _fit_to_width never drops sections
+        # that aren't in the priority list.
+        self.assertEqual(result, items)
+
+    def test_strips_ansi_when_measuring(self):
+        """Width math must use visible width, not raw byte length."""
+        from claude_statusline.cli import _fit_to_width
+        # Each item is 6 visible chars but ~16 bytes with ANSI.
+        items = [("bar", "\x1b[31m[####]\x1b[0m"),
+                 ("clock", "\x1b[90m12:34\x1b[0m"),
+                 ("cost", "\x1b[33m$1.20\x1b[0m")]
+        # Visible total = 6+5+5 = 16 + 2 seps of width 1 = 18. Fits in 20.
+        result = _fit_to_width(items, sep_visible_width=1, target_width=20,
+                               drop_priority=["clock"])
+        self.assertEqual(len(result), 3)  # nothing dropped
+
+    def test_preserves_order(self):
+        from claude_statusline.cli import _fit_to_width
+        items = [("a", "AA"), ("b", "BB"), ("c", "CC"), ("d", "DD")]
+        # Drop b but keep a, c, d in original order.
+        result = _fit_to_width(items, sep_visible_width=1, target_width=8,
+                               drop_priority=["b"])
+        names = [n for n, _ in result]
+        self.assertEqual(names, ["a", "c", "d"])
+
+
+class TestRenderFitsTerminalWidth(unittest.TestCase):
+    """End-to-end: render() must produce output where each line fits the
+    reported terminal width. This is the user-visible contract — Claude
+    Code's Ink TUI drops Line 2 if Line 1 exceeds the terminal width."""
+
+    def _measure_lines(self, output):
+        from claude_statusline.cli import _visible_width
+        return [_visible_width(line) for line in output.split("\n")]
+
+    def test_render_fits_at_120_cols(self):
+        """At 120 cols, every output line must be ≤ 120 visible chars."""
+        from claude_statusline.cli import render, _demo_data
+        old = os.environ.get("COLUMNS")
+        os.environ["COLUMNS"] = "120"
+        try:
+            out = render(_demo_data())
+            for w in self._measure_lines(out):
+                self.assertLessEqual(w, 120,
+                    "Line of width {} exceeds terminal width 120".format(w))
+        finally:
+            if old is None:
+                os.environ.pop("COLUMNS", None)
+            else:
+                os.environ["COLUMNS"] = old
+
+    def test_render_fits_at_150_cols(self):
+        from claude_statusline.cli import render, _demo_data
+        old = os.environ.get("COLUMNS")
+        os.environ["COLUMNS"] = "150"
+        try:
+            out = render(_demo_data())
+            for w in self._measure_lines(out):
+                self.assertLessEqual(w, 150)
+        finally:
+            if old is None:
+                os.environ.pop("COLUMNS", None)
+            else:
+                os.environ["COLUMNS"] = old
+
+    def test_render_fits_at_180_cols(self):
+        from claude_statusline.cli import render, _demo_data
+        old = os.environ.get("COLUMNS")
+        os.environ["COLUMNS"] = "180"
+        try:
+            out = render(_demo_data())
+            for w in self._measure_lines(out):
+                self.assertLessEqual(w, 180)
+        finally:
+            if old is None:
+                os.environ.pop("COLUMNS", None)
+            else:
+                os.environ["COLUMNS"] = old
 
 
 # ─── cli.py — rate limits section ────────────────────────────────────
@@ -3039,6 +3230,77 @@ class TestLine2FitsAt120Cols(unittest.TestCase):
                     idx + 1, visible
                 )
             )
+
+    def test_line2_fits_in_compact_band_with_vim_and_long_agent(self):
+        """The compact band (100-149 cols) must fit even with the heaviest
+        line2 sections — vim NORMAL active, long agent name, long branch.
+
+        This is the silent-failure mode that broke v0.5.4 before
+        _FIT_DROP_PRIORITY was introduced: the coarse pre-filter kept
+        burn/duration/lines/branch/vim/agent/model on Line 2, none of
+        which were in _COMPACT_DROP, so the precise stage was a no-op
+        and Line 2 silently overflowed at 110 cols. Pinning all three
+        widths (100/110/130) guarantees the precise stage covers them.
+        """
+        payload = self._heavy_payload()
+        payload["vim"] = {"mode": "NORMAL"}
+        payload["agent"] = {"name": "long-agent-name-stress-test"}
+        for cols in (100, 110, 130):
+            old = os.environ.get("COLUMNS")
+            os.environ["COLUMNS"] = str(cols)
+            try:
+                result = render(payload)
+            finally:
+                if old is None:
+                    del os.environ["COLUMNS"]
+                else:
+                    os.environ["COLUMNS"] = old
+            for idx, line in enumerate(result.split("\n")):
+                w = self._visible_width(line)
+                self.assertLessEqual(
+                    w, cols,
+                    "Line {} is {} visible chars at {}-col terminal "
+                    "(heavy + vim + long agent). _FIT_DROP_PRIORITY may "
+                    "be missing a section name from line2.".format(
+                        idx + 1, w, cols
+                    )
+                )
+
+    def test_rate_limits_recovered_at_180_cols(self):
+        """At 180 cols the precise stage should KEEP rate_limits visible
+        even though it lives in _COMPACT_DROP — because at 180 cols there
+        is room for it.
+
+        This pins the recovery property: someone who reverts the precise
+        stage or re-raises _FULL_LAYOUT_MIN_COLS to 230 would silently
+        lose this section, and the upper-bound width tests above would
+        not notice (overflow tests pass either way).
+        """
+        result = self._render_at_width(180)
+        # Rate-limit indicators look like "5h:46%" / "7d:68%" in the
+        # output (with ANSI color around them). Strip ANSI for the
+        # substring check.
+        plain = re.sub(r"\x1b\[[0-9;]*m", "", result)
+        self.assertIn(
+            "5h:", plain,
+            "rate_limits section was dropped at 180 cols even though "
+            "it should fit — precise stage may have over-dropped or "
+            "been disabled."
+        )
+
+    def test_rate_limits_dropped_at_120_cols(self):
+        """At 120 cols there is no room for rate_limits — the precise
+        stage must drop it. Inverse pin to test_rate_limits_recovered:
+        if the drop priority is broken or _COMPACT_DROP is bypassed,
+        rate_limits would leak through and overflow Line 2.
+        """
+        result = self._render_at_width(120)
+        plain = re.sub(r"\x1b\[[0-9;]*m", "", result)
+        self.assertNotIn(
+            "5h:", plain,
+            "rate_limits section was kept at 120 cols — would push "
+            "Line 2 past terminal width and trigger Ink truncation."
+        )
 
 
 # ─── sessions.py — disabled sections ────────────────────────────────


### PR DESCRIPTION
Closes #73 (tracking issue for the width-aware layout work).
Related: #53 (upstream Anthropic Ink truncation tracker).

## Summary

- **Two-stage layout**: coarse pre-filter by width bucket + precise post-render fit measuring actual visible width (stripping ANSI/OSC 8). Drops sections in priority order until each line fits the terminal — no more "230-col cliff" that hid all extras at once below the threshold.
- **Recovers sections in mid-width terminals**: rate_limits, speed, version, clock, commit_age, etc. now show on 150-220 col terminals where v0.5.3 hid them unconditionally.
- **Closes the silent compact-band overflow**: introduces `_FIT_DROP_PRIORITY` (extends `_COMPACT_DROP` with last-resort drops) so the precise stage can reach a fitting result even when the surviving compact-band sections are heavy (long agent name, vim mode, long branch+session).

## Why

Issue #53 tracks the upstream Claude Code bug (anthropics/claude-code#28750) where Ink's `wrap:"truncate"` silently drops Line 2 if Line 1 overflows. Anthropic never fixed it — the issue was closed by stalebot after 30 days of inactivity. Confirmed still present in cli.js for Claude Code 2.1.112.

The v0.5.3 workaround (raise threshold to 230 cols) was over-aggressive — it dropped many sections at once for everyone below 230 cols, which is most users. This PR keeps line-2 truncation prevented while restoring sections automatically as terminal width allows.

## Changes

### Production
- `claude_statusline/cli.py`:
  - `_visible_width(s)` strips SGR + OSC 8 (both ST `\x1b\` and BEL `\x07` terminators)
  - `_fit_to_width(named_items, sep_visible_width, target_width, drop_priority)` tracks total visible width incrementally — measures each section once, subtracts on drop
  - `_render_sections_named()` returns `(name, rendered)` pairs via a `_NamedAppender` helper that guards against unset section names
  - `_FIT_DROP_PRIORITY` adds last-resort drops (vim, agent, lines, duration, burn, model, cache, budget) on top of `_COMPACT_DROP`
  - `_FULL_LAYOUT_MIN_COLS` lowered 230 → 150
  - `--doctor` reports actual layout thresholds from the constants

### Documentation
- `README.md` — Responsive Layout section rewritten for the two-stage design; FAQ entry updated
- `ARCHITECTURE.md` — render pipeline and Responsive Layout sections refreshed (was still describing pre-v0.5.3 120/80 thresholds)
- `CHANGELOG.md` — v0.5.4 entry with Added/Changed/Fixed/Notes

### Tests (5 new, 284 total — all passing)
- ANSI/OSC 8 stripping including BEL-terminated form
- Priority-based drop algorithm correctness, ordering preservation, essential-section protection
- End-to-end heavy-payload width fit at 100/110/130 cols (the silent-failure compact band)
- Recovery: rate_limits visible at 180 cols, dropped at 120 cols (inverse pin)

## Review iterations

- 4 internal review agents flagged 5 critical/high issues — all addressed before initial commit (silent compact-band overflow, stale docstrings, OSC 8 BEL terminator, _NamedAppender guard, --doctor staleness)
- Gemini review: efficiency suggestion in `_fit_to_width` — addressed in 66941fe (incremental width tracking)

## Test plan
- [x] Full test suite passes: 284 tests, OK
- [x] Heavy-payload (vim active + long agent + long session_name + rate_limits) at 60/80/100/110/120/130/150/180/220/300 cols — zero overflow at every width
- [x] Recovery confirmed: rate_limits visible at 180 cols, dropped at 120 cols
- [x] `--doctor` reports correct compact band (100-149 cols) at COLUMNS=130
- [x] No new dependencies (stdlib only)