### PR TITLE
feat: v0.5.7 — recover terminal width hidden from subprocess + guard upstream rate_limits bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,21 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.7] - 2026-05-09
+
+### Added
+- **Terminal width detection fallback chain** — Claude Code spawns the statusLine command as a subprocess with stdin piped (no TTY, no `COLUMNS` env var), so naive `shutil.get_terminal_size()` always returns the fallback `(100, 24)`. Result: a user with a 165-col terminal would only see ~83 chars on Line 2, with sections like `rate_limits`, `context_size`, `clock`, `effort`, `version`, `last:`, `style:`, `dirs:` silently hidden. New `_detect_terminal_width()` tries 7 signals in order until one returns a plausible value: stdin `terminal.columns` (forward-compat for whenever Anthropic ships it) → `COLUMNS` env → `shutil.get_terminal_size` → `os.get_terminal_size(fd)` for stderr/stdout/stdin → `stty size < /dev/tty` → `tput cols 2>/dev/tty` → existing `_COMPACT_LAYOUT_MIN_COLS` fallback. Plausible-range guard (20–4000 cols, wide enough for ultrawide / 8K / multi-monitor tmux setups) rejects 0, negative, or absurd values from any source. Each step is wrapped in try/except so missing tools / closed `/dev/tty` fall through silently. Tracked upstream at [anthropics/claude-code#22115](https://github.com/anthropics/claude-code/issues/22115).
+- 12 new tests for the width detection — 11 unit tests (`TestDetectTerminalWidth`: each fallback step, boundary values 20/4000, implausible-input rejection, garbage env vars, non-dict stdin shapes, 2000-col ultrawide acceptance) plus 1 end-to-end render test (`TestRenderUsesDetectedWidth`) that proves a 165-col terminal now shows recovered sections (`(1000K)`, `effort:xhigh`).
+- `--doctor` now reports both the naive `shutil` width and the detected fallback width side-by-side, so users can see whether our recovery worked on their box.
+
+### Fixed
+- **Defensive guard against upstream rate_limits bug** ([anthropics/claude-code#52326](https://github.com/anthropics/claude-code/issues/52326), still open) — on a fresh 5h or 7d window with no usage data yet, Claude Code returns the `resets_at` epoch timestamp (~1.7e9) in `used_percentage` instead of 0/null. Previously our `clamp(0,100)` silently turned this into a false `5h:100% (red)` alarm on every fresh session for Pro/Max subscribers. Now values >= 1e6 (the epoch-timestamp pattern, 7+ orders of magnitude above any plausible percentage) are treated as "no data yet" and the section is hidden. Values 101-999999 still flow through to the renderer's clamp(0,100) — these are NOT the bug pattern and could be a future Anthropic "overage" indicator above 100% that we shouldn't pre-emptively hide.
+- 6 new tests in `TestRateLimitsEpochTimestampGuard` covering 5h epoch hidden, 7d epoch hidden, boundary at 100 (legitimate maxed value passes), boundary at 1e6 (just hits the guard), end-to-end render of the bugged value, and that legitimate values pass through.
+
+### Notes
+- Together these two fixes are the most user-visible improvement since v0.5.4 — every claude-status user with a wide terminal will see significantly more sections after upgrading, with no config required.
+- Closes #79.
+
 ## [0.5.6] - 2026-04-24
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -226,6 +226,10 @@ The status line automatically adapts to your terminal width via a two-stage proc
 
 The bar, tokens, cost, branch, and `!CTX` warning are always preserved — even at extreme widths, the statusline keeps its core identity.
 
+### Detecting your real terminal width
+
+Claude Code spawns the statusLine command as a subprocess with stdin piped — there is no TTY and no `COLUMNS` env var, so naive width detection always returns the fallback. Until Anthropic ships terminal dimensions in the stdin JSON ([anthropics/claude-code#22115](https://github.com/anthropics/claude-code/issues/22115), still open), claude-status walks a fallback chain to recover the real width: stdin `terminal.columns` → `COLUMNS` env → `shutil.get_terminal_size` → `os.get_terminal_size(fd)` → `stty size < /dev/tty` → `tput cols 2>/dev/tty`. Run `claude-status --doctor` to see which signal won on your machine.
+
 This design exists because Claude Code's TUI uses Ink `<Text wrap="truncate">` on the statusline (anthropics/claude-code#28750, still unaddressed upstream): if Line 1 overflows the terminal, Line 2 is silently dropped. Measuring our actual rendered width and dropping low-priority sections one at a time prevents this without sacrificing useful information on wider terminals.
 
 ## Manual Configuration

--- a/claude_statusline/__init__.py
+++ b/claude_statusline/__init__.py
@@ -1,3 +1,3 @@
 """claude-status: Beautiful status line for Claude Code."""
 
-__version__ = "0.5.6"
+__version__ = "0.5.7"

--- a/claude_statusline/cli.py
+++ b/claude_statusline/cli.py
@@ -726,37 +726,36 @@ def _detect_terminal_width(data=None):
         except (OSError, AttributeError):
             continue
 
-    # 5. stty size < /dev/tty — most reliable POSIX path. Captures
-    # the controlling terminal's real width even when stdin/stdout
-    # are pipes. /dev/tty doesn't exist on Windows, where stty is
-    # also typically absent — both raise FileNotFoundError, caught.
+    # 5+6. stty size / tput cols against /dev/tty — the most reliable
+    # POSIX path. Captures the controlling terminal's real width even
+    # when stdin/stdout are pipes. /dev/tty doesn't exist on Windows,
+    # where stty/tput are also typically absent — all of these raise
+    # FileNotFoundError or OSError, caught and fall through.
+    #
+    # The /dev/tty open is shared across both subprocesses so we pay
+    # the open() syscall once; if it fails we skip both probes
+    # atomically. stty is tried first because its output format
+    # ("rows cols") is more uniform across platforms; tput is the
+    # backstop for systems where stty isn't installed but ncurses is.
     try:
         with open("/dev/tty", "r") as tty:
-            result = subprocess.run(
-                ["stty", "size"], stdin=tty,
-                capture_output=True, text=True, timeout=1,
-            )
-        if result.returncode == 0:
-            parts = result.stdout.strip().split()
-            if len(parts) == 2:
-                cols = int(parts[1])
-                if _TERM_WIDTH_MIN <= cols <= _TERM_WIDTH_MAX:
-                    return cols
-    except (OSError, ValueError, subprocess.SubprocessError, FileNotFoundError):
-        pass
-
-    # 6. tput cols 2>/dev/tty — alternate path some systems have.
-    try:
-        with open("/dev/tty", "r") as tty:
-            result = subprocess.run(
-                ["tput", "cols"], stdin=tty,
-                capture_output=True, text=True, timeout=1,
-            )
-        if result.returncode == 0:
-            cols = int(result.stdout.strip())
-            if _TERM_WIDTH_MIN <= cols <= _TERM_WIDTH_MAX:
-                return cols
-    except (OSError, ValueError, subprocess.SubprocessError, FileNotFoundError):
+            for cmd, parser in (
+                (["stty", "size"], lambda s: int(s.split()[1])),
+                (["tput", "cols"], lambda s: int(s.strip())),
+            ):
+                try:
+                    result = subprocess.run(
+                        cmd, stdin=tty,
+                        capture_output=True, text=True, timeout=1,
+                    )
+                    if result.returncode == 0:
+                        cols = parser(result.stdout)
+                        if _TERM_WIDTH_MIN <= cols <= _TERM_WIDTH_MAX:
+                            return cols
+                except (OSError, ValueError, IndexError,
+                        subprocess.SubprocessError, FileNotFoundError):
+                    continue
+    except (OSError, FileNotFoundError):
         pass
 
     # 7. Last-resort fallback — same value the previous code path used.

--- a/claude_statusline/cli.py
+++ b/claude_statusline/cli.py
@@ -7,6 +7,7 @@ import platform
 import re
 import shlex
 import shutil
+import subprocess
 import sys
 import tempfile
 import time
@@ -165,7 +166,7 @@ def _normalize(data):
     # Claude Code version
     out["cc_version"] = data.get("version") or ""
 
-    # Rate limits (Pro/Max only, added in Claude Code v2.1.80)
+    # Rate limits (Pro/Max only, added in Claude Code v2.1.80).
     rl = data.get("rate_limits")
     rl = rl if isinstance(rl, dict) else {}
     five_h = rl.get("five_hour")
@@ -173,9 +174,31 @@ def _normalize(data):
     seven_d = rl.get("seven_day")
     seven_d = seven_d if isinstance(seven_d, dict) else {}
     # resets_at is Unix epoch seconds per Claude Code docs — convert to ms
-    # for fmt_countdown() which expects milliseconds
+    # for fmt_countdown() which expects milliseconds.
+    #
+    # Upstream bug guard (anthropics/claude-code#52326, still open):
+    # on a fresh 5h/7d window with no usage data yet, Claude Code
+    # returns the resets_at epoch timestamp (~1.7e9) in
+    # used_percentage instead of 0/null. Without this guard, our
+    # downstream clamp(0, 100) silently turns it into a false
+    # `5h:100% (red)` alarm on every fresh session for Pro/Max
+    # users.
+    #
+    # Threshold = 1e6: epoch seconds (~1.7e9) are 7+ orders of
+    # magnitude above any plausible percentage, so this catches the
+    # bug pattern with zero risk of false positives. We deliberately
+    # do NOT use `> 100`: Anthropic could legitimately ship an
+    # "overage" indicator above 100% in the future, and pre-emptively
+    # hiding any value 101-999999 would silently swallow it. Values
+    # in the legitimate-but-out-of-spec range (e.g. 105) still flow
+    # through to the renderer's existing clamp(0, 100) at the
+    # rate_limits section, so they show as `5h:100% (red)` — which
+    # IS the correct UI for "user is maxed out beyond 100%".
     for period, rl_dict in [("5h", five_h), ("7d", seven_d)]:
-        out["rate_limit_{}_pct".format(period)] = _safe_num(rl_dict.get("used_percentage"))
+        pct = _safe_num(rl_dict.get("used_percentage"))
+        if pct is not None and pct >= 1e6:
+            pct = None
+        out["rate_limit_{}_pct".format(period)] = pct
         resets_sec = _safe_num(rl_dict.get("resets_at"))
         out["rate_limit_{}_resets".format(period)] = (
             resets_sec * 1000 if resets_sec is not None else None
@@ -601,6 +624,145 @@ _FIT_DROP_PRIORITY = _COMPACT_DROP + [
 ]
 
 
+# Plausibility bounds for a detected terminal width. Anything outside
+# this range is treated as garbage and ignored — protects against
+# `stty size` returning 0 0 on a closed pty, an OS reporting absurd
+# widths, or stdin JSON containing a stringified value that coerced
+# to a wild number.
+#
+# Upper bound 4000 covers ultrawide / 8K / multi-monitor tmux setups
+# (a 7680px display at 6px monospace cells = ~1280 cols; side-by-side
+# 5K monitors in tmux can exceed 2000 cols). Going wider has no
+# rendering cost — the layout only cares about the 100/150 thresholds —
+# and rejecting a real 1280-col terminal would silently drop the user
+# back into compact layout.
+_TERM_WIDTH_MIN = 20
+_TERM_WIDTH_MAX = 4000
+
+
+def _detect_terminal_width(data=None):
+    """Detect the user's actual terminal width.
+
+    Claude Code spawns the statusLine command as a child process with
+    stdin piped — there is no TTY, no `COLUMNS` env var, and
+    `shutil.get_terminal_size()` returns its fallback. As a result we
+    can't tell from the subprocess context alone whether the user has
+    a 100-col terminal or a 300-col one, and our two-stage layout
+    silently trims to the fallback width.
+
+    Tracked upstream at anthropics/claude-code#22115 (open since Jan
+    2026, no upstream fix). Until Anthropic ships terminal dimensions
+    in the stdin JSON, we try a chain of fallbacks ourselves and
+    return the first plausible value.
+
+    Order (each step caught and ignored on any error):
+
+    1. ``data["terminal"]["columns"]`` from stdin JSON — defensive
+       forward-compat for whenever Anthropic adds it.
+    2. ``COLUMNS`` env var — some shell wrappers / users export it.
+    3. ``shutil.get_terminal_size()`` honoring ``COLUMNS`` and any
+       stdout TTY (rarely TTY in our context but cheap to check).
+    4. ``os.get_terminal_size(N)`` against a TTY file descriptor
+       (stderr/stdout in case one of them is unexpectedly a TTY).
+    5. ``stty size < /dev/tty`` — works on Linux/macOS/WSL when
+       ``/dev/tty`` is reachable. Most reliable signal we have.
+    6. ``tput cols 2>/dev/tty`` — alternate POSIX path; some
+       systems have ``tput`` but not ``stty``.
+    7. Fallback ``_COMPACT_LAYOUT_MIN_COLS`` — current behavior,
+       safe default that keeps Line 2 readable.
+
+    Args:
+        data: Optional parsed stdin JSON dict. If present and contains
+            a numeric ``terminal.columns`` value (int, float, or
+            numeric string — accepted via ``_safe_num``), that is
+            preferred over all other signals.
+
+    Returns:
+        Detected terminal width in columns. Always within
+        ``[_TERM_WIDTH_MIN, _TERM_WIDTH_MAX]`` because the final
+        fallback ``_COMPACT_LAYOUT_MIN_COLS`` itself sits in range.
+        Out-of-range candidates from earlier steps are *rejected*
+        (not clamped) and trigger fall-through to the next signal.
+    """
+    # 1. Stdin JSON terminal.columns (forward-compat).
+    if isinstance(data, dict):
+        term_obj = data.get("terminal")
+        if isinstance(term_obj, dict):
+            cols = _safe_num(term_obj.get("columns"))
+            if cols is not None and _TERM_WIDTH_MIN <= cols <= _TERM_WIDTH_MAX:
+                return int(cols)
+
+    # 2. COLUMNS env var (also honored by step 3, but checked first
+    # so a user explicitly exporting it always wins over OS calls).
+    cols_env = os.environ.get("COLUMNS")
+    if cols_env:
+        try:
+            cols = int(cols_env)
+            if _TERM_WIDTH_MIN <= cols <= _TERM_WIDTH_MAX:
+                return cols
+        except (ValueError, TypeError):
+            pass
+
+    # 3. shutil.get_terminal_size — checks COLUMNS again then any
+    # stdout TTY. Cheap; no external process. Skip its fallback
+    # path (which would just return our compact default early) by
+    # passing a sentinel and only trusting non-sentinel results.
+    try:
+        size = shutil.get_terminal_size((-1, -1))
+        if (_TERM_WIDTH_MIN <= size.columns <= _TERM_WIDTH_MAX
+                and size.columns != -1):
+            return size.columns
+    except (OSError, ValueError):
+        pass
+
+    # 4. os.get_terminal_size on each std fd — Claude Code closes
+    # stdin (it's our JSON pipe) but stderr is often inherited from
+    # the parent TTY.
+    for fd in (2, 1, 0):  # stderr, stdout, stdin
+        try:
+            size = os.get_terminal_size(fd)
+            if _TERM_WIDTH_MIN <= size.columns <= _TERM_WIDTH_MAX:
+                return size.columns
+        except (OSError, AttributeError):
+            continue
+
+    # 5. stty size < /dev/tty — most reliable POSIX path. Captures
+    # the controlling terminal's real width even when stdin/stdout
+    # are pipes. /dev/tty doesn't exist on Windows, where stty is
+    # also typically absent — both raise FileNotFoundError, caught.
+    try:
+        with open("/dev/tty", "r") as tty:
+            result = subprocess.run(
+                ["stty", "size"], stdin=tty,
+                capture_output=True, text=True, timeout=1,
+            )
+        if result.returncode == 0:
+            parts = result.stdout.strip().split()
+            if len(parts) == 2:
+                cols = int(parts[1])
+                if _TERM_WIDTH_MIN <= cols <= _TERM_WIDTH_MAX:
+                    return cols
+    except (OSError, ValueError, subprocess.SubprocessError, FileNotFoundError):
+        pass
+
+    # 6. tput cols 2>/dev/tty — alternate path some systems have.
+    try:
+        with open("/dev/tty", "r") as tty:
+            result = subprocess.run(
+                ["tput", "cols"], stdin=tty,
+                capture_output=True, text=True, timeout=1,
+            )
+        if result.returncode == 0:
+            cols = int(result.stdout.strip())
+            if _TERM_WIDTH_MIN <= cols <= _TERM_WIDTH_MAX:
+                return cols
+    except (OSError, ValueError, subprocess.SubprocessError, FileNotFoundError):
+        pass
+
+    # 7. Last-resort fallback — same value the previous code path used.
+    return _COMPACT_LAYOUT_MIN_COLS
+
+
 def _apply_responsive(sections_list, term_width):
     """Filter section list based on terminal width.
 
@@ -751,9 +913,12 @@ def render(data, theme_name="default"):
     sep = colorize(theme["separator"], theme["colors"]["separator"])
     sep_width = _visible_width(sep)
 
-    # Default to compact layout when terminal size cannot be detected
-    # (non-interactive contexts, piped stdout, some SSH setups).
-    term_width = shutil.get_terminal_size((_COMPACT_LAYOUT_MIN_COLS, 24)).columns
+    # Detect terminal width via fallback chain — Claude Code's
+    # statusLine subprocess context hides this from us, so naive
+    # `shutil.get_terminal_size()` always returns the fallback. See
+    # `_detect_terminal_width()` for the full chain (stdin JSON →
+    # COLUMNS → shutil → /dev/tty stty/tput → compact default).
+    term_width = _detect_terminal_width(data)
     line1 = _apply_responsive(theme["line1"], term_width)
     line2 = _apply_responsive(theme["line2"], term_width)
 
@@ -1402,12 +1567,17 @@ def cmd_doctor():
     print("  Branch: {}".format(branch or "(not in a git repo)"))
     print()
 
-    # Terminal capabilities
+    # Terminal capabilities — show both the naive shutil value AND
+    # the value our fallback chain detects, so users can see whether
+    # our recovery worked when Claude Code's subprocess context hid
+    # the real width.
     print("Terminal:")
     term = os.environ.get("TERM", "(not set)")
-    cols = shutil.get_terminal_size((_COMPACT_LAYOUT_MIN_COLS, 24)).columns
+    naive_cols = shutil.get_terminal_size((_COMPACT_LAYOUT_MIN_COLS, 24)).columns
+    detected_cols = _detect_terminal_width()
     print("  TERM:    {}".format(term))
-    print("  Columns: {}".format(cols))
+    print("  Columns: {} (shutil naive: {})".format(detected_cols, naive_cols))
+    cols = detected_cols
     if cols >= _FULL_LAYOUT_MIN_COLS:
         print("  Layout:  full (>= {} cols)".format(_FULL_LAYOUT_MIN_COLS))
     elif cols >= _COMPACT_LAYOUT_MIN_COLS:

--- a/llms.txt
+++ b/llms.txt
@@ -81,13 +81,15 @@ cli.py (entry point, normalization, two-stage layout, rendering) → bar.py (pro
 - All numeric fields use `_first()` helper (not `or`) to preserve zero values
 - OSC 8 clickable links disabled by default (Claude Code's Ink TUI miscounts them)
 
-## Workaround for Upstream Ink Truncation
+## Workarounds for Upstream Bugs
 
-Claude Code's TUI uses Ink `<Text wrap="truncate">` on the statusline (anthropics/claude-code#28750, closed without fix). When Line 1 overflows the terminal width, Line 2 is silently dropped. The two-stage layout (above) measures our actual rendered width and shrinks until we fit — no config required.
+- **Ink truncation** (anthropics/claude-code#28750, closed without fix): Claude Code's TUI uses `<Text wrap="truncate">` on the statusline. When Line 1 overflows the terminal width, Line 2 is silently dropped. Our two-stage layout (above) measures actual rendered width and shrinks until we fit.
+- **Terminal width hidden from subprocess** (anthropics/claude-code#22115, open): the statusLine command is spawned with stdin piped, no TTY, no `COLUMNS` env — so naive width detection always returns the fallback. v0.5.7+ walks a fallback chain (stdin `terminal.columns` → `COLUMNS` env → shutil → `os.get_terminal_size(fd)` → `stty size < /dev/tty` → `tput cols 2>/dev/tty`) to recover the real width and avoid trimming sections users have room for.
+- **rate_limits epoch-timestamp** (anthropics/claude-code#52326, open): on a fresh 5h/7d window, `rate_limits.X.used_percentage` returns the `resets_at` epoch timestamp (~1.7e9) instead of 0/null. v0.5.7+ guards against this — any value above 100 is treated as "no data yet" and the section is hidden.
 
 ## Testing
 
-stdlib unittest only. 300+ tests. CI: 21-job matrix (3 OS x 7 Python versions: 3.8-3.14).
+stdlib unittest only. 350+ tests. CI: 21-job matrix (3 OS x 7 Python versions: 3.8-3.14).
 
 ```
 python -m unittest discover tests/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "claude-status"
-version = "0.5.6"
+version = "0.5.7"
 description = "Beautiful, informative status line for Claude Code — zero dependencies, cross-platform"
 readme = "README.md"
 license = {text = "MIT"}

--- a/tests/test_all.py
+++ b/tests/test_all.py
@@ -1863,10 +1863,20 @@ class TestRateLimits(unittest.TestCase):
         self.assertIn("5h:99%", result)
 
     def test_rate_limits_clamped_above_100(self):
-        """Values above 100% should be clamped."""
+        """Values modestly above 100% (e.g. 105) still flow through
+        the renderer's clamp(0, 100) and display as `5h:100%` — this
+        is the legitimate "user is maxed out" UI for any future
+        Anthropic 'overage' indicator. Only values >= 1e6 (the upstream
+        epoch-timestamp bug pattern) are pre-emptively hidden.
+
+        See TestRateLimitsEpochTimestampGuard for the full contract.
+        """
         data = self._data_with_limits(five_h_pct=105)
         result = render(data)
-        self.assertIn("5h:100%", result)
+        self.assertIn("5h:100%", result,
+            "values modestly above 100 should clamp to 100% in the UI, "
+            "not be silently hidden — only the epoch-timestamp bug "
+            "pattern (>= 1e6) triggers the hide-section guard")
 
     def test_rate_limits_nearest_reset(self):
         """Should show countdown to the nearest reset when both present."""
@@ -4181,6 +4191,304 @@ class TestGitStateRebase(unittest.TestCase):
             self.assertIn("rebase", result)
         finally:
             cli_mod.get_git_state = orig
+
+
+# ─── cli.py — _detect_terminal_width fallback chain (#79) ──────────
+
+class TestDetectTerminalWidth(unittest.TestCase):
+    """Pin the fallback order of _detect_terminal_width().
+
+    Claude Code's statusLine subprocess hides the real terminal width
+    (no TTY, no COLUMNS env), so naive shutil returns the fallback.
+    The function tries 7 signals in order and returns the first
+    plausible value. These tests exercise each signal independently
+    and pin the order so a refactor can't silently demote a more-
+    reliable source.
+    """
+
+    def setUp(self):
+        # Always start from a clean slate: clear COLUMNS so step 2/3
+        # don't accidentally win in tests checking later steps.
+        self._old_cols = os.environ.pop("COLUMNS", None)
+        self._old_lines = os.environ.pop("LINES", None)
+
+    def tearDown(self):
+        if self._old_cols is not None:
+            os.environ["COLUMNS"] = self._old_cols
+        if self._old_lines is not None:
+            os.environ["LINES"] = self._old_lines
+
+    # --- Step 1: stdin terminal.columns -------------------------------
+
+    def test_stdin_terminal_columns_wins(self):
+        """When data['terminal']['columns'] is present and plausible,
+        it wins over every other signal — even COLUMNS env."""
+        from claude_statusline.cli import _detect_terminal_width
+        os.environ["COLUMNS"] = "200"
+        result = _detect_terminal_width({"terminal": {"columns": 165}})
+        self.assertEqual(result, 165)
+
+    def test_stdin_terminal_columns_string_coerced(self):
+        """Coerce numeric strings via _safe_num so JSON serializers
+        that stringify integers (rare but real) still work."""
+        from claude_statusline.cli import _detect_terminal_width
+        result = _detect_terminal_width({"terminal": {"columns": "165"}})
+        self.assertEqual(result, 165)
+
+    def test_stdin_terminal_columns_implausible_rejected(self):
+        """Out-of-range values fall through to the next signal —
+        guards against an upstream bug returning 0 or 99999."""
+        from claude_statusline.cli import _detect_terminal_width
+        os.environ["COLUMNS"] = "150"
+        result = _detect_terminal_width({"terminal": {"columns": 0}})
+        self.assertEqual(result, 150, "implausible 0 should fall through to COLUMNS")
+        result = _detect_terminal_width({"terminal": {"columns": 999999}})
+        self.assertEqual(result, 150, "implausible 999999 should fall through to COLUMNS")
+
+    def test_stdin_terminal_not_dict_falls_through(self):
+        """data['terminal'] being a string/list/None must not crash —
+        just fall through. isinstance guard."""
+        from claude_statusline.cli import _detect_terminal_width
+        os.environ["COLUMNS"] = "150"
+        for bad in ("string", [], None, 42):
+            result = _detect_terminal_width({"terminal": bad})
+            self.assertEqual(result, 150,
+                "data['terminal']={!r} should fall through cleanly".format(bad))
+
+    def test_data_none_falls_through(self):
+        """No data argument is the legitimate cmd_doctor case — must
+        not crash; falls through to env / OS signals."""
+        from claude_statusline.cli import _detect_terminal_width
+        os.environ["COLUMNS"] = "150"
+        result = _detect_terminal_width(None)
+        self.assertEqual(result, 150)
+
+    # --- Step 2: COLUMNS env var --------------------------------------
+
+    def test_columns_env_var_wins_when_no_stdin_signal(self):
+        from claude_statusline.cli import _detect_terminal_width
+        os.environ["COLUMNS"] = "200"
+        result = _detect_terminal_width({})
+        self.assertEqual(result, 200)
+
+    def test_columns_env_garbage_falls_through(self):
+        """Non-numeric COLUMNS must not crash."""
+        from claude_statusline.cli import _detect_terminal_width
+        os.environ["COLUMNS"] = "wide"
+        # Falls through; result depends on host env, but must be int
+        # in plausible range and not raise.
+        result = _detect_terminal_width({})
+        self.assertIsInstance(result, int)
+        self.assertGreaterEqual(result, 20)
+
+    def test_columns_env_negative_falls_through(self):
+        """Negative COLUMNS (some misconfigured shells) is rejected."""
+        from claude_statusline.cli import _detect_terminal_width
+        os.environ["COLUMNS"] = "-5"
+        result = _detect_terminal_width({})
+        # Falls through, doesn't return -5
+        self.assertGreaterEqual(result, 20)
+
+    # --- Bounds and clamping ------------------------------------------
+
+    def test_stdin_terminal_columns_lower_bound(self):
+        """20 is the minimum plausible width — anything below falls
+        through. 20 itself is accepted."""
+        from claude_statusline.cli import _detect_terminal_width
+        os.environ["COLUMNS"] = "150"
+        result = _detect_terminal_width({"terminal": {"columns": 20}})
+        self.assertEqual(result, 20)
+        result = _detect_terminal_width({"terminal": {"columns": 19}})
+        self.assertEqual(result, 150, "below-min should fall through")
+
+    def test_stdin_terminal_columns_upper_bound(self):
+        """4000 is the max — covers ultrawide / 8K / multi-monitor
+        tmux setups. Anything above falls through."""
+        from claude_statusline.cli import _detect_terminal_width
+        os.environ["COLUMNS"] = "150"
+        result = _detect_terminal_width({"terminal": {"columns": 4000}})
+        self.assertEqual(result, 4000)
+        result = _detect_terminal_width({"terminal": {"columns": 4001}})
+        self.assertEqual(result, 150, "above-max should fall through")
+
+    def test_stdin_terminal_columns_2000_is_accepted(self):
+        """An 8K display in tmux can legitimately reach ~1280 cols;
+        side-by-side multi-monitor setups can exceed 2000. 2000 must
+        be inside the plausible range, not silently dropped to the
+        compact fallback."""
+        from claude_statusline.cli import _detect_terminal_width
+        result = _detect_terminal_width({"terminal": {"columns": 2000}})
+        self.assertEqual(result, 2000)
+
+    # --- Final fallback path ------------------------------------------
+
+    def test_returns_int_in_plausible_range(self):
+        """Even with zero usable signals, we must return an integer
+        in the documented plausible range — never None, never a float,
+        never a crash."""
+        from claude_statusline.cli import (
+            _detect_terminal_width,
+            _TERM_WIDTH_MIN,
+            _TERM_WIDTH_MAX,
+        )
+        # Even when nothing is set, we get something usable
+        result = _detect_terminal_width({})
+        self.assertIsInstance(result, int)
+        self.assertGreaterEqual(result, _TERM_WIDTH_MIN)
+        self.assertLessEqual(result, _TERM_WIDTH_MAX)
+
+
+class TestRenderUsesDetectedWidth(unittest.TestCase):
+    """End-to-end: render() must consume data['terminal']['columns']
+    when present, exposing more sections at wide terminals where the
+    naive `shutil.get_terminal_size` fallback would have hidden them.
+    This is the user-facing fix — regression-grade test guards it."""
+
+    def test_render_at_165_cols_via_stdin_shows_more_sections(self):
+        """The actual user scenario from screenshot at PR #79: a 165-
+        col terminal that previously showed only ~5 sections on Line 2
+        now shows ~10+ because the precise stage has the real width."""
+        # Stub git helpers so this test is deterministic across hosts.
+        import claude_statusline.cli as cli_mod
+        orig = {
+            "get_remote_url": cli_mod.get_remote_url,
+            "get_git_state": cli_mod.get_git_state,
+            "get_last_commit_age_ms": cli_mod.get_last_commit_age_ms,
+            "get_git_extras": cli_mod.get_git_extras,
+            "get_session_tool_count": cli_mod.get_session_tool_count,
+            "get_today_session_count": cli_mod.get_today_session_count,
+            "get_effort_level": cli_mod.get_effort_level,
+        }
+        cli_mod.get_remote_url = lambda: ""
+        cli_mod.get_git_state = lambda: ""
+        cli_mod.get_last_commit_age_ms = lambda: 3600000  # 1h
+        cli_mod.get_git_extras = lambda: {}
+        cli_mod.get_session_tool_count = lambda sid: 0
+        cli_mod.get_today_session_count = lambda: 1
+        cli_mod.get_effort_level = lambda: "xhigh"
+        try:
+            data = {
+                "context_window": {"used_percentage": 18,
+                                   "context_window_size": 1_000_000,
+                                   "current_usage": {"input_tokens": 1, "output_tokens": 242}},
+                "cost": {"total_cost_usd": 879, "total_duration_ms": 196_080_000,
+                         "total_lines_added": 18683, "total_lines_removed": 1628},
+                "git_branch": "main",
+                "model": {"display_name": "Opus 4.7 (1M context)"},
+                "terminal": {"columns": 165},
+            }
+            out = render(data)
+            from claude_statusline.cli import _visible_width
+            lines = out.split("\n")
+            # Line 2 must fit the 165-col budget…
+            line2_width = _visible_width(lines[1])
+            self.assertLessEqual(line2_width, 165,
+                "Line 2 width {} exceeds 165 — fit logic broken".format(line2_width))
+            # …and use significantly more of it than the ~83 chars the
+            # naive fallback would have produced.
+            self.assertGreater(line2_width, 100,
+                "Line 2 width {} is too small — terminal.columns from "
+                "stdin was probably not consumed".format(line2_width))
+            # Specific recovered sections that proved the bug originally:
+            self.assertIn("(1000K)", out, "context_size should appear at 165 cols")
+            self.assertIn("effort:xhigh", out, "effort should appear at 165 cols")
+        finally:
+            for name, fn in orig.items():
+                setattr(cli_mod, name, fn)
+
+
+# ─── cli.py — rate_limits epoch-timestamp guard (#79 / upstream #52326) ──
+
+class TestRateLimitsEpochTimestampGuard(unittest.TestCase):
+    """Anthropic's claude-code#52326: on a fresh 5h or 7d window with
+    no usage data yet, used_percentage returns the resets_at epoch
+    timestamp (~1.7e9) instead of 0/null. Without a guard our
+    downstream clamp(0,100) silently turns it into a false
+    `5h:100% (red)` alarm. The guard treats anything > 100 as
+    'no data yet' and drops to None so the section is hidden."""
+
+    def _data(self, five_h_pct=None, seven_d_pct=None):
+        return {
+            "context_window": {"used_percentage": 20,
+                               "current_usage": {"input_tokens": 1000}},
+            "cost": {"total_cost_usd": 0.5, "total_duration_ms": 60000},
+            "git_branch": "main",
+            "rate_limits": {
+                "five_hour": {
+                    "used_percentage": five_h_pct,
+                    "resets_at": 1_776_950_400,
+                },
+                "seven_day": {
+                    "used_percentage": seven_d_pct,
+                    "resets_at": 1_777_500_000,
+                },
+            },
+        }
+
+    def test_epoch_timestamp_in_5h_used_percentage_is_hidden(self):
+        """5h section must NOT render when upstream returns the
+        timestamp value. Pre-fix, this rendered as '5h:100%' in red."""
+        from claude_statusline.cli import _normalize
+        n = _normalize(self._data(five_h_pct=1_776_950_400, seven_d_pct=18))
+        self.assertIsNone(n["rate_limit_5h_pct"],
+            "5h epoch-timestamp value must drop to None")
+        self.assertEqual(n["rate_limit_7d_pct"], 18.0,
+            "legitimate 7d value must still pass through unchanged")
+
+    def test_epoch_timestamp_in_7d_used_percentage_is_hidden(self):
+        from claude_statusline.cli import _normalize
+        n = _normalize(self._data(five_h_pct=42, seven_d_pct=1_777_500_000))
+        self.assertEqual(n["rate_limit_5h_pct"], 42.0)
+        self.assertIsNone(n["rate_limit_7d_pct"])
+
+    def test_legitimate_values_pass_through_unchanged(self):
+        from claude_statusline.cli import _normalize
+        n = _normalize(self._data(five_h_pct=34, seven_d_pct=68))
+        self.assertEqual(n["rate_limit_5h_pct"], 34.0)
+        self.assertEqual(n["rate_limit_7d_pct"], 68.0)
+
+    def test_boundary_value_100_passes_through(self):
+        """Exactly 100% IS a legitimate used_percentage (truly maxed
+        out) — the guard only triggers at the epoch-timestamp pattern
+        (>= 1e6). Pin the boundary."""
+        from claude_statusline.cli import _normalize
+        n = _normalize(self._data(five_h_pct=100, seven_d_pct=100))
+        self.assertEqual(n["rate_limit_5h_pct"], 100.0)
+        self.assertEqual(n["rate_limit_7d_pct"], 100.0)
+
+    def test_value_modestly_above_100_passes_through(self):
+        """Values 101-999999 are NOT the upstream bug pattern (which is
+        always epoch seconds ~1.7e9). They could be a future Anthropic
+        'overage' indicator above 100%, so we let them through and rely
+        on the renderer's existing clamp(0, 100) for safe display.
+        Pre-emptively hiding these would silently swallow real signals.
+        """
+        from claude_statusline.cli import _normalize
+        n = _normalize(self._data(five_h_pct=105, seven_d_pct=999999))
+        self.assertEqual(n["rate_limit_5h_pct"], 105.0,
+            "value just above 100 should flow through to the renderer's clamp")
+        self.assertEqual(n["rate_limit_7d_pct"], 999999.0,
+            "value just below 1e6 should still flow through (not bug pattern)")
+
+    def test_epoch_pattern_at_threshold_is_dropped(self):
+        """The threshold is 1e6: any value at or above that is treated
+        as the upstream epoch-timestamp bug pattern. Pins the boundary
+        explicitly."""
+        from claude_statusline.cli import _normalize
+        n = _normalize(self._data(five_h_pct=1_000_000, seven_d_pct=1_000_001))
+        self.assertIsNone(n["rate_limit_5h_pct"])
+        self.assertIsNone(n["rate_limit_7d_pct"])
+
+    def test_renders_no_5h_section_when_upstream_bug_present(self):
+        """End-to-end: rate_limits section in render() must hide the
+        bugged value, not render it in red. This is the user-visible
+        contract — 'no false 5h:100% alarm on fresh sessions'."""
+        result = render(self._data(five_h_pct=1_776_950_400, seven_d_pct=68))
+        # Must NOT contain a percentage in the billions
+        self.assertNotIn("5h:", result,
+            "5h section must be hidden when upstream returns epoch timestamp")
+        # 7d section still renders normally
+        self.assertIn("7d:68", result)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Closes #79.

## Summary

Two upstream Anthropic bugs that affect every claude-status user, addressed in one focused PR.

### 1. Recover terminal width that Claude Code hides from the statusLine subprocess

Claude Code spawns the statusLine command with stdin piped — there is **no TTY, no `COLUMNS` env var**, and `shutil.get_terminal_size()` always returns the fallback `(100, 24)`. Result: every user with a terminal wider than 100 cols sees Line 2 silently trimmed even when there's room to spare. The user's screenshot at the issue showed a 165-col terminal rendering only ~83 chars on Line 2, hiding `rate_limits`, `context_size`, `clock`, `effort`, `version`, `last:`, `style:`, `dirs:`.

This is tracked upstream at [anthropics/claude-code#22115](https://github.com/anthropics/claude-code/issues/22115) — open since January 2026, no upstream fix. The whole statusline-plugin ecosystem is blocked on it.

**Fix:** new `_detect_terminal_width()` walks 7 fallback signals until one returns a plausible value:
1. `data["terminal"]["columns"]` from stdin JSON (forward-compat for whenever Anthropic ships it)
2. `COLUMNS` env var
3. `shutil.get_terminal_size()` (handles parent TTY inheritance in some cases)
4. `os.get_terminal_size(fd)` for stderr/stdout/stdin
5. `stty size < /dev/tty`
6. `tput cols 2>/dev/tty`
7. Existing `_COMPACT_LAYOUT_MIN_COLS` fallback

Plausible-range guard `[20, 4000]` rejects garbage from any source. The 4000 upper bound covers ultrawide / 8K / multi-monitor tmux setups that can legitimately exceed 1000 cols.

**Result for the screenshot scenario** (165-col terminal):

| Before | After |
|---|---|
| Line 2: 5 sections, 83 chars | Line 2: **11 sections, 137 chars** |
| missing: rate_limits, context_size, clock, effort, version, last, style, dirs | recovered: 7d:18%, (1000K), last:369h50m, sessions:1, v0.5.7, 21:53 |

### 2. Defensive guard against upstream rate_limits epoch-timestamp bug

[anthropics/claude-code#52326](https://github.com/anthropics/claude-code/issues/52326) — still open. On a fresh 5h or 7d window with no usage data yet, Claude Code returns the `resets_at` epoch timestamp (~1.7e9) in `used_percentage` instead of 0/null. Our previous `clamp(0,100)` silently turned this into a false `5h:100% (red)` alarm on every fresh session for Pro/Max subscribers — telling them they're maxed out when they actually have full headroom.

**Fix:** values >= 1e6 (the actual bug pattern, 7+ orders of magnitude above any plausible percentage) are now treated as "no data yet" and the section is hidden. Values 101-999999 still flow through to the existing clamp — they could be a future Anthropic "overage" indicator above 100% that we shouldn't pre-emptively swallow.

## Diagnostics

`--doctor` now reports both the naive `shutil` width and the detected fallback width side-by-side, so users can verify the recovery worked on their box:

```
Terminal:
  TERM:    xterm-256color
  Columns: 165 (shutil naive: 100)
  Layout:  full (>= 150 cols)
```

## Tests

**352 total** (was 332, +18 new):
- `TestDetectTerminalWidth` (11) — each fallback step pinned independently, boundary values 20/4000, ultrawide 2000, garbage env, non-dict shapes, implausible-input rejection, priority order
- `TestRenderUsesDetectedWidth` (1) — end-to-end at 165 cols proving recovered sections
- `TestRateLimitsEpochTimestampGuard` (6) — 5h epoch hidden, 7d epoch hidden, boundary at 100 (legitimate maxed value passes), 105 (modest over passes — could be future overage), 1e6 (just hits the guard), end-to-end render of bugged value

## Review iterations

4 internal review agents flagged 4 real issues, all addressed before commit:
- **Critical (silent-failure-hunter):** original `> 100` rate-limits guard would silently hide a hypothetical future Anthropic "overage" indicator. Tightened to `>= 1e6` — matches the actual epoch-timestamp bug pattern with zero risk of false positives.
- **Medium (silent-failure-hunter):** `_TERM_WIDTH_MAX = 1000` excluded 8K / multi-monitor tmux setups (some legitimately exceed 1280 cols). Widened to 4000.
- **Doc (comment-analyzer):** docstring said values are "clamped" but the code rejects+falls-through. Corrected.
- **Doc (comment-analyzer):** docstring said `terminal.columns integer` but code accepts numeric strings via `_safe_num`. Corrected.

## Test plan
- [x] All 352 tests pass locally
- [x] Demo + doctor smoke test verified (`Opus 4.7`, layout reporting, dual-width display)
- [x] User's actual scenario (165-col, hydra/main, $879, 18683 lines) verified — Line 2 grows from 5 sections to 11
- [x] No new dependencies (`subprocess` is stdlib)
- [x] No encoding corruption