### PR TITLE
v0.8.0: render pr.review_state + add thinking section

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,21 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.8.0] - 2026-06-27
+
+### Added
+
+- **PR review-state rendering** ([#99](https://github.com/mkalkere/claude-statusline/issues/99) follow-up) — the `pr` section now renders `pr.review_state` as a short token appended to the PR number: `PR#1234 ok` (approved), `chg` (changes_requested), `rev` (pending), `draft`. The value was already captured and enum-validated in `_normalize()` since v0.6.3 (which deferred rendering to a follow-up); this release adds the renderer with no change to the capture path. The token is appended **outside** the OSC 8 hyperlink envelope so the clickable target stays exactly `PR#N` and the state reads as an adjacent annotation. Per-state color is themeable via `pr_review_<state>` keys (default: green/red/yellow/dim), falling through with `_first()` so a theme setting the key to `null` degrades to the default rather than crashing. Hidden — section degrades to bare `PR#N` — whenever `review_state` is absent or fails the documented enum (`approved`/`pending`/`changes_requested`/`draft`); the lookup is total over every value that survives normalization, so a desync between the validation set and the render map can't `KeyError`. A deliberately ASCII token (not an emoji) keeps it width-1-per-char and renders identically in every terminal, consistent with the rest of the statusline. Opt-in: rides along automatically wherever the `pr` section is already enabled.
+
+- **`thinking` section** — renders a `think` badge from the documented `thinking.enabled` stdin boolean. Surfaces only the affirmative case (`thinking.enabled` strictly `True`): an "off" indicator would be noise on every non-thinking session. `_normalize()` reduces the field to a strict bool via `is True` (not truthiness), so a malformed non-bool like `enabled: 1` does not masquerade as the documented value, and an `isinstance(dict)` guard mirrors every other nested-object read so `thinking: "yes"` (string) can't crash. Pairs naturally with `effort` — both describe how the model is reasoning this session. Color is themeable via the `thinking` key (default magenta). Opt-in via custom theme initially, matching the rollout of `pr` / `cost_breakdown`; may promote to a default-theme section if user feedback is positive.
+
+### Notes
+
+- **Both features are pure upstream-field consumers.** No new heuristics, no config parsing of undocumented files — they read documented stdin fields and degrade gracefully when absent, exactly like every other section. Verified against the live Claude Code statusline schema as of 2026-06-27. The audit that motivated this release also confirmed the `COLUMNS`/`LINES` env handoff is already consumed by the width-detection chain and `context_window.remaining_percentage` is already derivable — neither needed new code.
+- **`thinking` and `pr` (with review state) are dropped early under width pressure** — both are listed in `_COMPACT_DROP` (which feeds the narrow and precise-fit drop priorities) so they shed before essential sections on narrow terminals. The bar/tokens/cost/branch identity is never dropped.
+- All 562 tests pass (was 549, +13 net new in `tests/test_all.py`: 9 for `pr.review_state` (enum accept, case-insensitivity across single- and multi-word states, unknown/non-string reject, per-state token render, bare-PR fallback, render-map↔enum sync guard, per-state theme color override applied, null-override fall-through to default color, and `_COMPACT_DROP` membership) and 4 for `thinking` (strict-True normalize, renders-when-enabled, hidden for off/absent/malformed, and `_COMPACT_DROP` membership)). Pure stdlib, no dependency changes.
+- Closes the `pr.review_state` rendering follow-up from [#99](https://github.com/mkalkere/claude-statusline/issues/99).
+
 ## [0.7.0] - 2026-06-05
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -78,7 +78,8 @@ The setup wizard walks you through theme selection, budget configuration, and in
 | Output Style | `style:explanatory` | Active output style when set |
 | Added Dirs | `dirs:+2` | Extra directories added via `/add-dir` |
 | Effort Level | `effort:high` | Thinking effort: `low`, `high`, `xhigh`, or `max`. Shown when non-default. Read from stdin JSON `effort.level` (Claude Code v2.1.119+) for instant updates; falls back to `~/.claude/settings.json` for older versions. (The `/effort ultracode` setting reports as `xhigh` per Claude Code's documented enum; an `ultra` value from earlier installs is accepted as a silent alias that renders as `xhigh`.) |
-| Pull Request | `PR#86` | Current GitHub PR number when detected, clickable to the PR page via OSC 8. Reads `pr.number` / `pr.url` from stdin (newer Claude Code releases) with `github.pr_number` / `github.pr_url` as a fallback for older releases. Opt-in via custom theme. |
+| Thinking | `think` | Shown when extended thinking is enabled for the session. Reads `thinking.enabled` from stdin; surfaces only the on state (an off badge would be noise). Opt-in via custom theme. |
+| Pull Request | `PR#86 ok` | Current GitHub PR number when detected, clickable to the PR page via OSC 8. Reads `pr.number` / `pr.url` from stdin (newer Claude Code releases) with `github.pr_number` / `github.pr_url` as a fallback for older releases. When `pr.review_state` is present, a short status token follows the number: `ok` (approved), `chg` (changes requested), `rev` (pending review), `draft`. Opt-in via custom theme. |
 | Cost Breakdown | `mcp:$0.80` | Largest non-base cost category from `cost.by_category` (newer Claude Code releases). Falls back to `other:$N` (sum) when no single category exceeds $0.01 but multiple together do. Opt-in via custom theme. |
 | Version | `v0.5.0` | claude-status version |
 | CC Version | `CC:2.1.92` | Claude Code application version |

--- a/claude_statusline/__init__.py
+++ b/claude_statusline/__init__.py
@@ -1,3 +1,3 @@
 """claude-status: Beautiful status line for Claude Code."""
 
-__version__ = "0.7.0"
+__version__ = "0.8.0"

--- a/claude_statusline/cli.py
+++ b/claude_statusline/cli.py
@@ -45,11 +45,26 @@ CTX_WARNING_THRESHOLD_PCT = 85
 # as of 2026-06-04). Used by _normalize to membership-check the
 # captured value so a malformed upstream value never reaches
 # downstream consumers. Module-private — not part of the public API
-# surface; rendering of review state is tracked separately and may
-# change shape before it ships.
+# surface. Rendered by the `pr` section via _PR_REVIEW_DISPLAY, whose
+# keys must stay in sync with this set (asserted by
+# TestPRReviewState.test_display_map_stays_in_sync_with_enum).
 _PR_REVIEW_STATES = frozenset({
     "approved", "pending", "changes_requested", "draft",
 })
+
+# Render mapping for pr.review_state: each documented state → (short
+# ASCII token, default color). The token is deliberately ASCII (not an
+# emoji) so it is width-1-per-char and renders identically in every
+# terminal — consistent with the rest of the statusline. Keys MUST stay
+# in sync with _PR_REVIEW_STATES; the test suite asserts the two sets
+# are identical so a future state added to one can't silently desync the
+# other. Per-state theme override key is "pr_review_<state>".
+_PR_REVIEW_DISPLAY = {
+    "approved":          ("ok",    GREEN),
+    "changes_requested": ("chg",   RED),
+    "pending":           ("rev",   YELLOW),
+    "draft":             ("draft", BRIGHT_BLACK),
+}
 
 
 def _force_utf8():
@@ -223,9 +238,11 @@ def _normalize(data):
     # those names continues to work. The keys describe what claude-
     # status STORES, not which upstream namespace they came from.
     #
-    # pr.review_state is captured internally but NOT rendered in this
-    # release; tracked separately. Capturing now lets the rendering
-    # land in a follow-up without re-touching _normalize.
+    # pr.review_state is captured here and rendered by the `pr` section
+    # (see _PR_REVIEW_DISPLAY and the section == "pr" block in
+    # _render_sections). v0.6.3 added the capture and deferred the
+    # rendering; v0.8.0 landed the renderer without re-touching this
+    # normalize block.
     pr_obj = data.get("pr")
     pr_obj = pr_obj if isinstance(pr_obj, dict) else {}
     github_obj = data.get("github")
@@ -266,10 +283,9 @@ def _normalize(data):
         or _clean_pr_url(github_obj.get("pr_url"))
     )
 
-    # Review state: captured but not rendered in this release.
-    # Membership-checked against the documented enum so a malformed
-    # value never reaches downstream. Module-private to keep the
-    # public-API surface unchanged.
+    # Review state: membership-checked against the documented enum so a
+    # malformed value never reaches the renderer. Rendered by the `pr`
+    # section via _PR_REVIEW_DISPLAY.
     #
     # `.lower()` parity with `effort.level` / `effortLevel`: the
     # documented values are lowercase (`approved`, `pending`, etc.)
@@ -498,6 +514,23 @@ def _normalize(data):
     else:
         out["effort_level"] = None
 
+    # Extended-thinking state (thinking.enabled, documented stdin field).
+    # Stored as a STRICT bool — `is True` collapses every input to exactly
+    # True or False, so the renderer never sees None:
+    #   enabled is True            -> True   (render the section)
+    #   enabled False / absent /
+    #     non-bool / non-dict      -> False  (hide)
+    # We only surface the affirmative case — an "off" indicator would be
+    # noise on every non-thinking session, so the "explicitly off" and
+    # "field missing" inputs deliberately collapse to the same hidden
+    # state. isinstance(dict) guard mirrors every other nested-object read
+    # in _normalize so a malformed `thinking: "yes"` (string) can't crash.
+    # Strict `is True` rather than truthiness so a stray non-bool like
+    # `enabled: 1` does not masquerade as the documented boolean.
+    thinking_obj = data.get("thinking")
+    thinking_obj = thinking_obj if isinstance(thinking_obj, dict) else {}
+    out["thinking_enabled"] = thinking_obj.get("enabled") is True
+
     return out
 
 
@@ -655,6 +688,34 @@ def _render_sections_named(n, order, theme):
                 pr_text = colorize("PR#{}".format(pr_number), pr_color)
                 if pr_url:
                     pr_text = _osc8_link(pr_url, pr_text)
+
+                # Review state (pr.review_state, captured since v0.6.3,
+                # rendered here). A short ASCII token rather than an
+                # emoji glyph keeps it width-1-per-char and renders in
+                # every terminal — same conservative choice the project
+                # makes elsewhere. Appended OUTSIDE the OSC 8 link so
+                # the clickable target stays exactly "PR#N" and the
+                # state reads as an adjacent annotation.
+                #
+                # _normalize gates the value against _PR_REVIEW_STATES,
+                # and TestPRReviewState asserts that set equals the
+                # _PR_REVIEW_DISPLAY keys — so today every value that
+                # reaches us is a valid map key. The lookup still uses
+                # .get() (not a bare subscript) as defense-in-depth: if a
+                # future state were ever added to one set but not the
+                # other, an unmapped value degrades to a bare "PR#N"
+                # (this section) rather than raising KeyError and taking
+                # down the WHOLE line. Per-section graceful degradation is
+                # the project contract; the sync test stays as the loud
+                # signal that catches the desync in CI first.
+                review = n.get("pr_review_state")
+                entry = _PR_REVIEW_DISPLAY.get(review) if review else None
+                if entry:
+                    label, default_color = entry
+                    state_color = _first(tc.get("pr_review_" + review),
+                                         default_color)
+                    pr_text = pr_text + " " + colorize(label, state_color)
+
                 sections.append(pr_text)
 
         elif section == "burn" and total_tokens and duration:
@@ -938,6 +999,19 @@ def _render_sections_named(n, order, theme):
                     "effort:" + effort, ec, BOLD
                 ))
 
+        elif section == "thinking":
+            # Extended-thinking indicator (thinking.enabled, documented
+            # stdin field). _normalize reduces the field to a strict
+            # bool in n["thinking_enabled"]; we render ONLY when True —
+            # an "off" badge would clutter every non-thinking session.
+            # Pairs naturally with `effort`; both describe how the model
+            # is reasoning this session. Color falls through via _first()
+            # so a theme setting `thinking: null` degrades to BRIGHT_MAGENTA
+            # rather than crashing colorize().
+            if n.get("thinking_enabled"):
+                thc = _first(tc.get("thinking"), BRIGHT_MAGENTA)
+                sections.append(colorize("think", thc, BOLD))
+
         elif section == "git_extras":
             branch = n["git_branch"] or get_branch()
             if branch:
@@ -1018,7 +1092,7 @@ _COMPACT_DROP = [
     "git_extras", "version", "cc_version", "clock", "worktree",
     "sessions", "tools", "activity", "latency", "context_size", "session_name",
     "rate_limits", "output_style", "added_dirs", "effort", "git_worktree",
-    "speed", "git_state", "commit_age", "cost_breakdown", "pr",
+    "speed", "git_state", "commit_age", "cost_breakdown", "pr", "thinking",
 ]
 _NARROW_DROP = _COMPACT_DROP + [
     "cache", "burn", "lines", "budget", "agent", "model",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "claude-status"
-version = "0.7.0"
+version = "0.8.0"
 description = "Beautiful, informative status line for Claude Code — zero dependencies, cross-platform"
 readme = "README.md"
 license = {text = "MIT"}

--- a/tests/test_all.py
+++ b/tests/test_all.py
@@ -37,6 +37,11 @@ from claude_statusline.git import get_branch
 from claude_statusline.themes import THEMES, get_theme
 from claude_statusline.cli import render, _render_sections, _settings_path
 
+# Distinct sentinel meaning "omit this key entirely" in test helpers,
+# kept separate from None so tests can exercise both "key absent" and
+# "key present but null" — two different code paths in _normalize.
+_SENTINEL = object()
+
 
 # ─── colors.py ────────────────────────────────────────────────────────
 
@@ -6304,6 +6309,198 @@ class TestGitHubPRSection(unittest.TestCase):
         finally:
             THEMES["default"]["line2"] = orig_line2
             cli_mod.get_branch = orig_branch
+
+
+class TestPRReviewState(unittest.TestCase):
+    """`pr.review_state` (documented stdin enum: approved / pending /
+    changes_requested / draft) is captured since v0.6.3 and rendered as
+    a short ASCII token appended to the PR section. Hidden when absent or
+    malformed — the section degrades to bare PR#NN."""
+
+    def _plain(self, output):
+        no_ansi = re.sub(r"\x1b\[[0-9;]*m", "", output)
+        return re.sub(r"\x1b\]8;;[^\x07\x1b]*(?:\x07|\x1b\\)", "", no_ansi)
+
+    def _render_with_pr(self, review_state):
+        import claude_statusline.cli as cli_mod
+        from claude_statusline.themes import THEMES
+        orig_line2 = THEMES["default"]["line2"]
+        orig_branch = cli_mod.get_branch
+        cli_mod.get_branch = lambda: "main"
+        try:
+            THEMES["default"]["line2"] = ["pr", "branch"]
+            pr = {"number": 86, "url": "https://github.com/x/y/pull/86"}
+            if review_state is not _SENTINEL:
+                pr["review_state"] = review_state
+            return self._plain(cli_mod.render(
+                {"pr": pr, "git_branch": "main"}, "default"))
+        finally:
+            THEMES["default"]["line2"] = orig_line2
+            cli_mod.get_branch = orig_branch
+
+    def test_normalize_accepts_documented_states(self):
+        from claude_statusline.cli import _normalize
+        for state in ("approved", "pending", "changes_requested", "draft"):
+            n = _normalize({"pr": {"number": 1, "review_state": state},
+                            "session_id": "x"})
+            self.assertEqual(n["pr_review_state"], state)
+
+    def test_normalize_case_insensitive(self):
+        """Production lower-cases before the enum check — parity with
+        effort.level. Covers the multi-word `changes_requested` form
+        too, so the underscore survives case-folding."""
+        from claude_statusline.cli import _normalize
+        for raw, want in (("APPROVED", "approved"),
+                          ("Changes_Requested", "changes_requested"),
+                          ("Pending", "pending"),
+                          ("DRAFT", "draft")):
+            n = _normalize({"pr": {"number": 1, "review_state": raw},
+                            "session_id": "x"})
+            self.assertEqual(n["pr_review_state"], want,
+                "{!r} must normalize to {!r}".format(raw, want))
+
+    def test_normalize_rejects_unknown_and_nonstring(self):
+        from claude_statusline.cli import _normalize
+        for bad in ("merged", "", 42, ["approved"], {"x": 1}, True, None):
+            n = _normalize({"pr": {"number": 1, "review_state": bad},
+                            "session_id": "x"})
+            self.assertIsNone(n["pr_review_state"],
+                "review_state={!r} must normalize to None".format(bad))
+
+    def test_render_each_state_token(self):
+        for state, token in (("approved", "ok"),
+                             ("changes_requested", "chg"),
+                             ("pending", "rev"),
+                             ("draft", "draft")):
+            plain = self._render_with_pr(state)
+            self.assertIn("PR#86", plain)
+            self.assertIn("PR#86 {}".format(token), plain,
+                "state {!r} should render token {!r}".format(state, token))
+
+    def test_render_bare_pr_when_state_absent_or_bad(self):
+        for bad in (_SENTINEL, "merged", 42, None):
+            plain = self._render_with_pr(bad)
+            self.assertIn("PR#86", plain)
+            # No stray review token should follow the PR number.
+            for token in ("ok", "chg", "rev", "draft"):
+                self.assertNotIn("PR#86 {}".format(token), plain,
+                    "bad/absent state {!r} must not render {!r}".format(
+                        bad, token))
+
+    def test_display_map_stays_in_sync_with_enum(self):
+        """The render map keys MUST equal the validated enum — a state
+        added to one but not the other would either crash the KeyError
+        lookup in render or silently drop a valid value."""
+        from claude_statusline.cli import (
+            _PR_REVIEW_STATES, _PR_REVIEW_DISPLAY)
+        self.assertEqual(set(_PR_REVIEW_DISPLAY), set(_PR_REVIEW_STATES))
+
+    def _render_raw_with_pr(self, review_state, color_overrides):
+        """Render with `pr` enabled and the given theme color overrides,
+        returning the RAW (un-stripped) output so callers can assert on
+        the actual ANSI color codes wrapping the review token."""
+        import claude_statusline.cli as cli_mod
+        from claude_statusline.themes import THEMES
+        orig_line2 = THEMES["default"]["line2"]
+        orig_colors = THEMES["default"]["colors"]
+        orig_branch = cli_mod.get_branch
+        cli_mod.get_branch = lambda: "main"
+        try:
+            THEMES["default"]["line2"] = ["pr", "branch"]
+            THEMES["default"]["colors"] = dict(orig_colors)
+            THEMES["default"]["colors"].update(color_overrides)
+            pr = {"number": 86, "url": "https://github.com/x/y/pull/86",
+                  "review_state": review_state}
+            return cli_mod.render({"pr": pr, "git_branch": "main"}, "default")
+        finally:
+            THEMES["default"]["line2"] = orig_line2
+            THEMES["default"]["colors"] = orig_colors
+            cli_mod.get_branch = orig_branch
+
+    def test_per_state_color_override_applied(self):
+        """The per-state theme key `pr_review_<state>` actually colors
+        the token — assert the override ANSI code wraps it, not just that
+        the token text appears."""
+        raw = self._render_raw_with_pr("approved",
+                                       {"pr_review_approved": CYAN})
+        self.assertIn(CYAN + "ok" + RESET, raw,
+            "pr_review_approved override must wrap the 'ok' token in CYAN")
+
+    def test_per_state_color_null_falls_through_to_default(self):
+        """An explicit `null` override must fall through `_first()` to the
+        built-in default color (RED for changes_requested) and NOT crash
+        colorize() — the theme-null degradation contract the project
+        guards elsewhere."""
+        raw = self._render_raw_with_pr(
+            "changes_requested", {"pr_review_changes_requested": None})
+        self.assertIn(RED + "chg" + RESET, raw,
+            "null override must fall through to the default RED, not crash")
+
+    def test_pr_is_compact_droppable(self):
+        """`pr` must shed under width pressure before essential sections.
+        Pins membership in _COMPACT_DROP (which feeds both _NARROW_DROP
+        and _FIT_DROP_PRIORITY) so a refactor can't silently break the
+        documented 'sheds first' contract."""
+        from claude_statusline.cli import (
+            _COMPACT_DROP, _NARROW_DROP, _FIT_DROP_PRIORITY)
+        self.assertIn("pr", _COMPACT_DROP)
+        self.assertIn("pr", _NARROW_DROP)
+        self.assertIn("pr", _FIT_DROP_PRIORITY)
+
+
+class TestThinkingSection(unittest.TestCase):
+    """`thinking.enabled` (documented stdin boolean) renders a `think`
+    badge ONLY when strictly True. Off / absent / malformed all hide it —
+    an off-indicator would be noise on every non-thinking session."""
+
+    def _plain(self, output):
+        return re.sub(r"\x1b\[[0-9;]*m", "", output)
+
+    def _shows_think(self, thinking_value):
+        import claude_statusline.cli as cli_mod
+        from claude_statusline.themes import THEMES
+        orig_line2 = THEMES["default"]["line2"]
+        orig_branch = cli_mod.get_branch
+        cli_mod.get_branch = lambda: "main"
+        try:
+            THEMES["default"]["line2"] = ["thinking", "branch"]
+            data = {"git_branch": "main"}
+            if thinking_value is not _SENTINEL:
+                data["thinking"] = thinking_value
+            return "think" in self._plain(cli_mod.render(data, "default"))
+        finally:
+            THEMES["default"]["line2"] = orig_line2
+            cli_mod.get_branch = orig_branch
+
+    def test_normalize_true_only(self):
+        from claude_statusline.cli import _normalize
+        self.assertTrue(
+            _normalize({"thinking": {"enabled": True}, "session_id": "x"})
+            ["thinking_enabled"])
+        for falsey in ({"enabled": False}, {"enabled": 1}, {"enabled": "yes"},
+                       {}, "on", 42, ["enabled"], None):
+            n = _normalize({"thinking": falsey, "session_id": "x"})
+            self.assertIs(n["thinking_enabled"], False,
+                "thinking={!r} must normalize to False".format(falsey))
+
+    def test_renders_only_when_enabled(self):
+        self.assertTrue(self._shows_think({"enabled": True}))
+
+    def test_hidden_for_off_absent_and_malformed(self):
+        for val in ({"enabled": False}, {"enabled": 1}, _SENTINEL,
+                    "yes", 42, None):
+            self.assertFalse(self._shows_think(val),
+                "thinking={!r} must not render the badge".format(val))
+
+    def test_thinking_is_compact_droppable(self):
+        """`thinking` must shed under width pressure before essential
+        sections. Pins membership in _COMPACT_DROP (which feeds both
+        _NARROW_DROP and _FIT_DROP_PRIORITY)."""
+        from claude_statusline.cli import (
+            _COMPACT_DROP, _NARROW_DROP, _FIT_DROP_PRIORITY)
+        self.assertIn("thinking", _COMPACT_DROP)
+        self.assertIn("thinking", _NARROW_DROP)
+        self.assertIn("thinking", _FIT_DROP_PRIORITY)
 
 
 class TestCostBreakdownSection(unittest.TestCase):


### PR DESCRIPTION
## Summary

Two new sections, both pure consumers of **documented** Claude Code stdin fields, surfaced by auditing the live statusline schema (2.1.195) against what `cli.py` reads. No new heuristics, no undocumented-file parsing — they read documented fields and degrade gracefully when absent, exactly like every other section.

### `pr.review_state` rendering
The `pr` section now appends a short status token after the PR number:

| `review_state` | token | default color |
|---|---|---|
| `approved` | `PR#1234 ok` | green |
| `changes_requested` | `PR#1234 chg` | red |
| `pending` | `PR#1234 rev` | yellow |
| `draft` | `PR#1234 draft` | dim |

The value was captured and enum-validated in `_normalize` since v0.6.3 (which deferred rendering to a follow-up); this lands the renderer with **no change to the capture path**. The token is appended **outside** the OSC 8 hyperlink envelope so the clickable target stays exactly `PR#N`. Per-state color is themeable via `pr_review_<state>` keys with `_first()` null-fallthrough. The lookup uses `.get()` so a future enum/display-map desync degrades the *section* to bare `PR#N` rather than `KeyError`-ing the *whole line* (a sync test stays as the loud CI signal).

### `thinking` section
Renders a `think` badge from the documented `thinking.enabled` stdin boolean. Strict `is True` (not truthiness) so a non-bool like `enabled: 1` can't masquerade as the documented value; `isinstance(dict)` guard mirrors every other nested read. Surfaces only the on-state — an off badge would be per-session noise. Pairs naturally with `effort`.

## Rollout
Both are **opt-in via custom theme** (matching the `pr` / `cost_breakdown` rollout) and listed in `_COMPACT_DROP` so they shed first under width pressure — the bar/tokens/cost/branch identity is never dropped.

## Audit notes
The same audit confirmed two candidates need **no** new code: the `COLUMNS`/`LINES` env handoff is already consumed by the width-detection chain, and `context_window.remaining_percentage` is already derivable.

## Tests
+13 net new (562 total, all passing under `python -m unittest discover tests/`). Covers present / absent / empty / null / non-dict / non-string / wrong-type for both fields, case-insensitivity (incl. multi-word `Changes_Requested`), the render-map↔enum sync guard, per-state color override + null fall-through (asserting actual ANSI), and `_COMPACT_DROP` membership. Pure stdlib, zero dependency changes.

## Review
Ran the 4-agent PR review cycle (code-reviewer, test-analyzer, silent-failure-hunter, comment-analyzer) plus a verification re-review; iterated to zero outstanding issues. Findings addressed: bare-subscript → `.get()` hardening, three stale "not rendered" comments, a `BRIGHT_MAGENTA` comment fix, tri-state wording, and three added/strengthened tests.

Follows up on the `pr.review_state` rendering deferred in #99.