### PR TITLE
feat: add cache_age section — time since last assistant turn (#92)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,30 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.9.0] - 2026-07-02
+
+### Added
+
+- **`cache_age` section** ([#92](https://github.com/mkalkere/claude-statusline/issues/92)) — renders `cache_age:4m12s`, the wall-clock time since the last assistant turn. Useful as a cue for how long a long-running task has been going and, in particular, whether Anthropic's ~5-minute prompt cache is still warm. Past the cache TTL (`_CACHE_AGE_WARN_MS`, 5 min) the chip switches to a warning color to flag that the cache has likely gone cold; under it, a muted default color. Opt-in via custom theme, matching the rollout of `thinking` / `pr` / `cost_breakdown`.
+
+  - **Reads real, already-present data.** The age is derived from the `timestamp` field of the most recent assistant message in `transcript_path` — the same stdin field the `activity` section already tail-reads. No new stdin dependency, no undocumented-file parsing.
+
+  - **Reuses the proven transcript reader.** `get_last_assistant_timestamp_ms()` mirrors `get_session_activity_count()`'s defense-in-depth exactly: the `transcript_path` must resolve (via `realpath`, symlink-aware) under `~/.claude/` before any read; only the last 64 KiB is tail-read (the newest assistant message is always at EOF, so no 1 MiB retry is needed as it is for the activity reader's backward walk to a *user* message); and every error path — invalid/non-string path, missing/empty/unreadable file, no assistant message in the window, unparseable timestamp — degrades to `None` so the section hides rather than crashes.
+
+  - **Live-to-the-second despite caching.** The reader caches the *timestamp* (not the derived age) for 5 s, and the renderer recomputes the age against the current clock every render — so the displayed value ticks up smoothly while the transcript read stays cached. A cache *miss* is cached too (as a `{"ts": None}` sentinel) so a long user-only pause doesn't re-tail the file every render.
+
+  - **Clock-skew safe.** A future-dated last message (skew between the machine that wrote the transcript and the one rendering) yields a negative age; the section hides rather than render a nonsense `cache_age:-3s`. `--doctor` reports the future-dated case explicitly so a silently-hidden section still leaves a diagnostic trail.
+
+  - **Python 3.8+ safe timestamp parse.** `_parse_iso8601_ms()` swaps a trailing `Z` for `+00:00` before `datetime.fromisoformat()` so it parses the transcript's `2026-07-02T23:00:49.920Z` form on Python 3.8–3.10 (where `fromisoformat` doesn't accept `Z`) as well as 3.11+. A naive timestamp with no offset is assumed UTC rather than crashed on.
+
+### Notes
+
+- **Pure upstream-field consumer**, consistent with `thinking` / `pr`: reads a documented stdin-derived field and degrades gracefully when absent. No new heuristics, no dependency changes, pure stdlib.
+- **Dropped early under width pressure** — `cache_age` is listed in `_COMPACT_DROP` (which feeds the narrow and precise-fit drop priorities) so it sheds before essential sections on narrow terminals. The bar/tokens/cost/branch identity is never dropped.
+- **`--doctor` gained a `Cache age:` probe line** alongside the existing `Activity:`/`Parse:` transcript diagnostics, so users debugging a missing `cache_age` section can see whether the last assistant timestamp is extractable and what age it yields.
+- All 585 tests pass (was 564, +21 new: ISO-8601 parser edge cases, the tail extractor with path-validation / caching / schema-fallback coverage, and end-to-end render including the warn threshold, future-timestamp hiding, and droppable membership). Pure stdlib, no dependency changes.
+- Closes [#92](https://github.com/mkalkere/claude-statusline/issues/92).
+
 ## [0.8.1] - 2026-06-27
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ The setup wizard walks you through theme selection, budget configuration, and in
 | Git Worktree | `gwt` | Indicator when inside a native git worktree |
 | Tool Calls | `tools:42` | Number of tool calls in current session |
 | Activity | `act:3` | Live tool-call counter for the current assistant turn — resets on each user prompt (opt-in; reads transcript tail, 5s cache, hidden when zero) |
+| Cache Age | `cache_age:4m12s` | Time since the last assistant turn — a cue for how long a task has run and whether the ~5-min prompt cache is still warm. Warning color past 5 min. Reads the last assistant message timestamp from the transcript tail (opt-in; 5s cache, hidden when unavailable). |
 | Sessions Today | `sessions:3` | How many sessions you've started today |
 | Session Name | `✦ refactor auth` | Custom session name (via `--name` or `/rename`) |
 | Vim Mode | `NORMAL` | Blue for NORMAL, green for INSERT |

--- a/claude_statusline/__init__.py
+++ b/claude_statusline/__init__.py
@@ -1,3 +1,3 @@
 """claude-status: Beautiful status line for Claude Code."""
 
-__version__ = "0.8.1"
+__version__ = "0.9.0"

--- a/claude_statusline/cli.py
+++ b/claude_statusline/cli.py
@@ -33,13 +33,21 @@ from .sessions import (
     _canonical_effort, _count_activity_with_status,
     _read_cache, _write_cache,
     get_budget_config, get_clickable_links_enabled, get_compaction_threshold,
-    get_disabled_sections, get_effort_level, get_session_activity_count,
+    get_disabled_sections, get_effort_level, get_last_assistant_timestamp_ms,
+    get_session_activity_count,
     get_session_tool_count, get_today_session_count,
 )
 from .themes import THEMES, get_theme
 
 # Percentage of context window usage that triggers the !CTX warning.
 CTX_WARNING_THRESHOLD_PCT = 85
+
+# cache_age (#92): milliseconds since the last assistant turn beyond
+# which the section renders in a warning color, signalling the prompt
+# cache has likely gone cold. Anthropic's prompt cache TTL is ~5
+# minutes; we mirror that default here. This is a display heuristic
+# only — it never changes behavior, just the color the user sees.
+_CACHE_AGE_WARN_MS = 5 * 60 * 1000
 
 # Documented review states for pr.review_state (statusline doc enum
 # as of 2026-06-04). Used by _normalize to membership-check the
@@ -857,6 +865,40 @@ def _render_sections_named(n, order, theme):
                         + colorize(str(act_count), act_color)
                     )
 
+        elif section == "cache_age":
+            # Time since the most recent assistant message (#92) — a cue
+            # for how long a task has been running / whether the ~5-min
+            # prompt cache is still warm. Reads the transcript tail via
+            # the same cached, path-validated reader as `activity`.
+            #
+            # We recompute the age from the (cached) timestamp against
+            # the current clock on every render, so the displayed value
+            # stays live-to-the-second even though the transcript read
+            # itself is cached for 5s. Past _CACHE_AGE_WARN_MS the chip
+            # switches to a warning color (cache likely cold).
+            #
+            # Hidden when: no transcript, no assistant message in the
+            # tail (ts None), or the age is negative — a future-dated
+            # timestamp (clock skew between the machine that wrote the
+            # transcript and this render) would otherwise produce a
+            # nonsense `cache_age:-3s`, so we suppress rather than show
+            # it. Color falls through via _first() so a theme setting
+            # `cache_age`/`cache_age_warn` to null degrades gracefully.
+            transcript = n.get("transcript_path", "")
+            if transcript:
+                ts_ms = get_last_assistant_timestamp_ms(transcript)
+                if ts_ms is not None:
+                    age_ms = int(time.time() * 1000) - ts_ms
+                    if age_ms >= 0:
+                        if age_ms >= _CACHE_AGE_WARN_MS:
+                            cagec = _first(tc.get("cache_age_warn"), YELLOW)
+                        else:
+                            cagec = _first(tc.get("cache_age"), BRIGHT_BLACK)
+                        sections.append(
+                            colorize("cache_age:", tc["label"])
+                            + colorize(fmt_duration(age_ms), cagec)
+                        )
+
         elif section == "sessions":
             count = get_today_session_count()
             if count > 0:
@@ -1106,9 +1148,10 @@ _RELAXED_MIN_CC_VERSION = (2, 1, 141)
 # Below _FULL_LAYOUT_MIN_COLS: drop least-essential sections progressively.
 _COMPACT_DROP = [
     "git_extras", "version", "cc_version", "clock", "worktree",
-    "sessions", "tools", "activity", "latency", "context_size", "session_name",
-    "rate_limits", "output_style", "added_dirs", "effort", "git_worktree",
-    "speed", "git_state", "commit_age", "cost_breakdown", "pr", "thinking",
+    "sessions", "tools", "activity", "cache_age", "latency", "context_size",
+    "session_name", "rate_limits", "output_style", "added_dirs", "effort",
+    "git_worktree", "speed", "git_state", "commit_age", "cost_breakdown",
+    "pr", "thinking",
 ]
 _NARROW_DROP = _COMPACT_DROP + [
     "cache", "burn", "lines", "budget", "agent", "model",
@@ -2504,6 +2547,22 @@ def cmd_doctor():
             count, status = _count_activity_with_status(most_recent)
             print("  Activity:    {} tool_use(s) since last user message".format(count))
             print("  Parse:       {}".format(status))
+            # Probe the cache_age reader too so users debugging a
+            # missing `cache_age` section can see whether the last
+            # assistant timestamp is extractable and what age it
+            # yields. A future-dated timestamp (clock skew) is reported
+            # explicitly since the renderer hides it — otherwise the
+            # section would silently vanish with no diagnostic trail.
+            ts_ms = get_last_assistant_timestamp_ms(most_recent)
+            if ts_ms is None:
+                print("  Cache age:   no assistant timestamp in tail window")
+            else:
+                age_s = time.time() - ts_ms / 1000.0
+                if age_s < 0:
+                    print("  Cache age:   last assistant message is future-dated "
+                          "by {:.0f}s (clock skew) — section hidden".format(-age_s))
+                else:
+                    print("  Cache age:   {:.0f}s since last assistant message".format(age_s))
         except (OSError, ValueError) as exc:
             # Narrow to expected failure modes; programmer errors
             # (AttributeError, ImportError) bubble up so they're seen.

--- a/claude_statusline/sessions.py
+++ b/claude_statusline/sessions.py
@@ -4,6 +4,7 @@ Reads ~/.claude/ data files to provide aggregate metrics across sessions.
 Uses file-based caching to avoid expensive filesystem scans on every render.
 """
 
+import datetime
 import hashlib
 import json
 import os
@@ -14,6 +15,13 @@ import time
 _CACHE_TTL = 30  # seconds — longer than git cache since this is heavier
 _TOOL_CACHE_TTL = 10  # seconds — shorter for active session metrics
 _ACTIVITY_CACHE_TTL = 5  # seconds — shortest, this metric is "right now"
+# cache_age (#92) measures wall-clock time since the last assistant
+# message. Cache the *timestamp* (not the derived age) for 5s: the
+# timestamp is stable between reads, and the renderer recomputes the
+# age from it against the current clock every render, so the displayed
+# value stays live-to-the-second even while the underlying transcript
+# read is cached. Matches the activity metric's "right now" TTL.
+_CACHE_AGE_CACHE_TTL = 5
 # Longer TTL for the "gave up — turn larger than 1 MiB window" case.
 # This is a per-render 1 MiB tail read that will keep failing the
 # same way until the user sends the next prompt. 30s caps the worst-
@@ -345,6 +353,178 @@ def get_session_activity_count(transcript_path):
     elif status.startswith("no user message in 1 MiB"):
         _write_cache(gave_up_key, {"count": 0})
     return count
+
+
+def get_last_assistant_timestamp_ms(transcript_path):
+    """Epoch-ms timestamp of the most recent assistant message, or None.
+
+    Powers the ``cache_age`` section (#92): "how long since the last
+    assistant turn." The renderer derives a live age by subtracting
+    this from the current clock every render, which is why we cache the
+    *timestamp* rather than the age — the timestamp is stable between
+    transcript reads, so a 5s read cache never makes the displayed age
+    stale (the age is recomputed against ``time.time()`` each render).
+
+    Reads only the tail of the transcript (same windowing, path
+    validation, and error-swallowing contract as
+    :func:`get_session_activity_count`). Returns None — never raises —
+    on any degrade path (invalid/missing/unreadable file, no assistant
+    message in the tail window, unparseable timestamp), so the renderer
+    hides the section rather than crash.
+
+    Args:
+        transcript_path: Path to the session transcript JSONL from
+            Claude Code's stdin JSON. Validated as a real regular file
+            under ~/.claude/ before any read, identical to the
+            activity reader's defense-in-depth check.
+
+    Returns:
+        int epoch-milliseconds of the newest assistant message's
+        ``timestamp`` field, or None when unavailable. Future-dated or
+        otherwise implausible timestamps are returned as-is; the
+        renderer clamps a negative age to hidden so a clock skew can't
+        render a nonsense ``cache_age:-3s``.
+    """
+    if not transcript_path or not isinstance(transcript_path, str):
+        return None
+
+    # Defense-in-depth path check — identical rationale to
+    # get_session_activity_count: transcript_path is external input, so
+    # require the resolved real path to live under ~/.claude/ (resolved
+    # on both sides so relocated-via-symlink layouts still work).
+    try:
+        real = os.path.realpath(transcript_path)
+        if not real.startswith(_CLAUDE_DIR_REAL + os.sep) and real != _CLAUDE_DIR_REAL:
+            return None
+    except (OSError, ValueError):
+        return None
+
+    path_hash = hashlib.md5(
+        transcript_path.encode("utf-8", errors="replace")
+    ).hexdigest()[:12]
+    cache_key = "cache_age_ts_{}".format(path_hash)
+
+    cached = _read_cache(cache_key, ttl=_CACHE_AGE_CACHE_TTL)
+    if cached is not None:
+        # A cached miss (no assistant message found) is stored as the
+        # sentinel {"ts": None} so we don't re-read the tail every
+        # render during a long user-only pause. `.get` returns None for
+        # both "sentinel miss" and "malformed cache entry" — both mean
+        # "hide," so collapsing them is correct.
+        return cached.get("ts")
+
+    ts_ms = _last_assistant_timestamp_from_tail(transcript_path)
+    # Cache both hit and miss for the short TTL: a miss is a legitimate
+    # steady state (user hasn't sent a prompt whose response reached the
+    # tail window yet) and re-reading the tail every render for 5s buys
+    # nothing. Unlike the activity gave-up path, there's no 1 MiB retry
+    # here, so the read is always cheap and a flat 5s TTL is sufficient.
+    _write_cache(cache_key, {"ts": ts_ms})
+    return ts_ms
+
+
+def _last_assistant_timestamp_from_tail(transcript_path):
+    """Tail-read the transcript and return the newest assistant
+    message's epoch-ms timestamp, or None.
+
+    Pure function (no caching) — the caching wrapper is
+    :func:`get_last_assistant_timestamp_ms`. Walks the tail lines
+    backwards and returns the first assistant message's parsed
+    ``timestamp``. Uses the same single 64 KiB tail as the activity
+    reader's first pass: the most-recent assistant message is, by
+    definition, at the very end of the file, so a small tail always
+    reaches it (unlike the activity reader, which must reach back to a
+    possibly-distant *user* message and therefore needs the 1 MiB
+    retry). No expanded retry is needed here.
+    """
+    try:
+        if not os.path.isfile(transcript_path):
+            return None
+        size = os.path.getsize(transcript_path)
+        if size <= 0:
+            return None
+    except (OSError, IOError):
+        return None
+
+    try:
+        start = max(0, size - _TRANSCRIPT_TAIL_BYTES)
+        with open(transcript_path, "rb") as f:
+            f.seek(start)
+            chunk = f.read()
+    except (OSError, IOError):
+        return None
+
+    try:
+        text = chunk.decode("utf-8", errors="replace")
+    except (UnicodeDecodeError, AttributeError):
+        return None
+
+    lines = text.split("\n")
+    # Drop the leading partial line when we started mid-file (same guard
+    # as _parse_transcript_tail): if the chunk doesn't begin at a line
+    # boundary, lines[0] is a truncated fragment we must not parse.
+    if start > 0 and lines and not chunk.startswith(b"\n"):
+        lines = lines[1:]
+
+    for i in range(len(lines) - 1, -1, -1):
+        line = lines[i]
+        # Cheap pre-filter before json.loads on every line: an
+        # assistant message line must mention both keys. Avoids parsing
+        # user/tool_result lines that dominate a transcript.
+        if '"timestamp"' not in line or '"assistant"' not in line:
+            continue
+        try:
+            entry = json.loads(line)
+        except (json.JSONDecodeError, ValueError):
+            continue
+        if not isinstance(entry, dict):
+            continue
+        # role lives on the inner message object on most schema
+        # versions, with an outer-envelope fallback (mirrors the
+        # activity reader's dual-location handling).
+        msg = entry.get("message")
+        is_assistant = (
+            (isinstance(msg, dict) and msg.get("role") == "assistant")
+            or entry.get("role") == "assistant"
+        )
+        if not is_assistant:
+            continue
+        ts = _parse_iso8601_ms(entry.get("timestamp"))
+        if ts is not None:
+            return ts
+    return None
+
+
+def _parse_iso8601_ms(value):
+    """Parse a Claude Code transcript ISO-8601 timestamp to epoch ms.
+
+    Transcript timestamps look like ``2026-07-02T23:00:49.920Z`` (UTC,
+    trailing Z). Returns int epoch-milliseconds, or None for any input
+    that isn't a well-formed string timestamp — a non-string, empty
+    string, or unparseable value all degrade to None so the caller
+    hides the section rather than crash.
+
+    Uses ``datetime.fromisoformat`` (stdlib, no deps). Python 3.11+
+    parses the trailing ``Z`` directly; for 3.10 and earlier we swap
+    ``Z`` for ``+00:00`` first, since ``fromisoformat`` there raises
+    ``ValueError`` on a bare ``Z``. This project supports Python 3.8+
+    (see ``requires-python`` in pyproject.toml), so the swap is
+    REQUIRED — not optional — for correct parsing on 3.8–3.10.
+    """
+    if not isinstance(value, str) or not value:
+        return None
+    try:
+        text = value[:-1] + "+00:00" if value.endswith("Z") else value
+        dt = datetime.datetime.fromisoformat(text)
+        # A naive timestamp (no offset) is assumed UTC — Claude Code
+        # always emits the trailing Z, so this only guards a malformed
+        # upstream that dropped it; treating it as UTC is the least-
+        # surprising degrade.
+        if dt.tzinfo is None:
+            dt = dt.replace(tzinfo=datetime.timezone.utc)
+        return int(dt.timestamp() * 1000)
+    except (ValueError, OverflowError, OSError):
+        return None
 
 
 def _count_activity_from_transcript(transcript_path):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "claude-status"
-version = "0.8.1"
+version = "0.9.0"
 description = "Beautiful, informative status line for Claude Code — zero dependencies, cross-platform"
 readme = "README.md"
 license = {text = "MIT"}

--- a/tests/test_all.py
+++ b/tests/test_all.py
@@ -884,6 +884,39 @@ class TestCLISubprocess(unittest.TestCase):
         self.assertIn("Python:", result.stdout)
         self.assertIn("OS:", result.stdout)
 
+    def test_doctor_cache_age_probe(self):
+        """--doctor reports a `Cache age:` line derived from the most
+        recent transcript under ~/.claude/projects/. We plant a fixture
+        with a FUTURE mtime so it is deterministically selected as the
+        most-recent file, then assert the normal-age wording. Cleaned up
+        in finally so the user's real ~/.claude/projects/ is untouched.
+        """
+        import shutil as shutil_mod
+        from claude_statusline import sessions as sessions_mod
+        projects = os.path.join(sessions_mod._CLAUDE_DIR, "projects")
+        os.makedirs(projects, exist_ok=True)
+        fixture_dir = tempfile.mkdtemp(prefix="cacheage-doctor-", dir=projects)
+        fixture = os.path.join(fixture_dir, "session.jsonl")
+        ts = time.strftime(
+            "%Y-%m-%dT%H:%M:%S.000Z", time.gmtime(time.time() - 42))
+        try:
+            with open(fixture, "w", encoding="utf-8", newline="") as f:
+                f.write(json.dumps({
+                    "type": "assistant",
+                    "message": {"role": "assistant", "content": []},
+                    "timestamp": ts}) + "\n")
+            # Bump mtime into the future so the doctor's most-recent
+            # selection deterministically picks this fixture regardless
+            # of what else lives under ~/.claude/projects/.
+            future = time.time() + 3600
+            os.utime(fixture, (future, future))
+            result = self._run(["--doctor"])
+            self.assertEqual(result.returncode, 0)
+            self.assertIn("Cache age:", result.stdout)
+            self.assertIn("since last assistant message", result.stdout)
+        finally:
+            shutil_mod.rmtree(fixture_dir, ignore_errors=True)
+
 
 # ─── Issue #6: API latency ────────────────────────────────────────────
 
@@ -6666,6 +6699,402 @@ class TestThinkingSection(unittest.TestCase):
         self.assertIn("thinking", _COMPACT_DROP)
         self.assertIn("thinking", _NARROW_DROP)
         self.assertIn("thinking", _FIT_DROP_PRIORITY)
+
+
+class TestParseIso8601Ms(unittest.TestCase):
+    """`_parse_iso8601_ms` converts Claude Code transcript timestamps
+    (ISO-8601 UTC with trailing Z) to epoch ms, degrading to None for
+    any malformed input rather than raising."""
+
+    def test_parses_z_suffixed_utc(self):
+        from claude_statusline.sessions import _parse_iso8601_ms
+        # 2026-07-02T23:00:49.920Z — a real transcript-shaped value.
+        ms = _parse_iso8601_ms("2026-07-02T23:00:49.920Z")
+        self.assertIsNotNone(ms)
+        # Round-trips back to the same UTC wall-clock second.
+        got = time.gmtime(ms / 1000.0)
+        self.assertEqual((got.tm_year, got.tm_mon, got.tm_mday,
+                          got.tm_hour, got.tm_min, got.tm_sec),
+                         (2026, 7, 2, 23, 0, 49))
+
+    def test_parses_offset_form(self):
+        from claude_statusline.sessions import _parse_iso8601_ms
+        # Explicit +00:00 offset (some schema versions) must also parse.
+        self.assertIsNotNone(_parse_iso8601_ms("2026-07-02T23:00:49+00:00"))
+
+    def test_naive_timestamp_assumed_utc(self):
+        """A timestamp with no offset (malformed upstream that dropped
+        the Z) is assumed UTC, not crashed on."""
+        from claude_statusline.sessions import _parse_iso8601_ms
+        z = _parse_iso8601_ms("2026-07-02T23:00:49.920Z")
+        naive = _parse_iso8601_ms("2026-07-02T23:00:49.920")
+        self.assertIsNotNone(naive)
+        self.assertEqual(z, naive)
+
+    def test_malformed_returns_none(self):
+        from claude_statusline.sessions import _parse_iso8601_ms
+        for bad in (None, "", "not-a-date", 42, [], {}, "2026-13-99T99:99Z",
+                    True, 1783046343072):
+            self.assertIsNone(_parse_iso8601_ms(bad),
+                "_parse_iso8601_ms({!r}) must be None".format(bad))
+
+
+class TestLastAssistantTimestamp(unittest.TestCase):
+    """`get_last_assistant_timestamp_ms` reads the transcript tail and
+    returns the newest assistant message's epoch-ms timestamp, mirroring
+    the activity reader's path-validation, tail-read, and caching."""
+
+    def _write_transcript(self, lines):
+        f = tempfile.NamedTemporaryFile(
+            mode="w", encoding="utf-8", suffix=".jsonl",
+            delete=False, newline="", dir=self._test_dir,
+        )
+        for entry in lines:
+            f.write(json.dumps(entry) + "\n")
+        f.close()
+        self._created_paths.append(f.name)
+        return f.name
+
+    def _iso(self, secs_ago):
+        return time.strftime(
+            "%Y-%m-%dT%H:%M:%S.000Z",
+            time.gmtime(time.time() - secs_ago))
+
+    def setUp(self):
+        import shutil as shutil_mod
+        from claude_statusline import sessions as sessions_mod
+        self._shutil_mod = shutil_mod
+        self._sessions_mod = sessions_mod
+        os.makedirs(sessions_mod._CLAUDE_DIR, exist_ok=True)
+        self._test_dir = tempfile.mkdtemp(
+            prefix="claude-status-cacheage-", dir=sessions_mod._CLAUDE_DIR,
+        )
+        self._created_paths = []
+        self._clear_cache()
+
+    def _clear_cache(self):
+        # cache_age uses its own key prefix; clear it so the 5s TTL
+        # doesn't leak between tests.
+        try:
+            cache_dir = self._sessions_mod._cache_dir()
+            if os.path.isdir(cache_dir):
+                for name in os.listdir(cache_dir):
+                    if name.startswith("cache_age_ts_"):
+                        try:
+                            os.remove(os.path.join(cache_dir, name))
+                        except OSError:
+                            pass
+        except OSError:
+            pass
+
+    def tearDown(self):
+        self._shutil_mod.rmtree(self._test_dir, ignore_errors=True)
+
+    def test_returns_newest_assistant_timestamp(self):
+        from claude_statusline.sessions import get_last_assistant_timestamp_ms
+        path = self._write_transcript([
+            {"type": "user", "message": {"role": "user", "content": "hi"},
+             "timestamp": self._iso(300)},
+            {"type": "assistant",
+             "message": {"role": "assistant", "content": []},
+             "timestamp": self._iso(200)},
+            {"type": "assistant",
+             "message": {"role": "assistant", "content": []},
+             "timestamp": self._iso(30)},
+        ])
+        ms = get_last_assistant_timestamp_ms(path)
+        self.assertIsNotNone(ms)
+        # ~30s ago, not the 200s-ago earlier assistant line.
+        age = time.time() - ms / 1000.0
+        self.assertTrue(20 <= age <= 45, "expected ~30s age, got {}".format(age))
+
+    def test_outer_envelope_role_fallback(self):
+        """Some schema versions put role on the outer envelope, not the
+        inner message. The reader must handle both."""
+        from claude_statusline.sessions import get_last_assistant_timestamp_ms
+        path = self._write_transcript([
+            {"role": "assistant", "timestamp": self._iso(15)},
+        ])
+        self.assertIsNotNone(get_last_assistant_timestamp_ms(path))
+
+    def test_no_assistant_message_returns_none(self):
+        from claude_statusline.sessions import get_last_assistant_timestamp_ms
+        path = self._write_transcript([
+            {"type": "user", "message": {"role": "user", "content": "hi"},
+             "timestamp": self._iso(10)},
+        ])
+        self.assertIsNone(get_last_assistant_timestamp_ms(path))
+
+    def test_missing_timestamp_field_skipped(self):
+        """An assistant line missing the timestamp key is filtered by
+        the cheap substring pre-filter; the reader keeps walking back
+        for an earlier one that has one."""
+        from claude_statusline.sessions import get_last_assistant_timestamp_ms
+        path = self._write_transcript([
+            {"type": "assistant",
+             "message": {"role": "assistant", "content": []},
+             "timestamp": self._iso(50)},
+            {"type": "assistant",
+             "message": {"role": "assistant", "content": []}},  # no ts key
+        ])
+        ms = get_last_assistant_timestamp_ms(path)
+        # Falls back to the earlier line's timestamp (~50s ago).
+        self.assertIsNotNone(ms)
+        age = time.time() - ms / 1000.0
+        self.assertTrue(40 <= age <= 65, "expected ~50s, got {}".format(age))
+
+    def test_unparseable_timestamp_falls_through(self):
+        """A newest assistant line whose timestamp is PRESENT but
+        unparseable (passes the substring pre-filter, fails
+        _parse_iso8601_ms) must fall through to the previous valid
+        assistant line — the reader's per-line continue branch."""
+        from claude_statusline.sessions import get_last_assistant_timestamp_ms
+        path = self._write_transcript([
+            {"type": "assistant",
+             "message": {"role": "assistant", "content": []},
+             "timestamp": self._iso(40)},
+            {"type": "assistant",
+             "message": {"role": "assistant", "content": []},
+             "timestamp": "not-a-real-timestamp"},  # present but garbage
+        ])
+        ms = get_last_assistant_timestamp_ms(path)
+        self.assertIsNotNone(ms)
+        age = time.time() - ms / 1000.0
+        self.assertTrue(30 <= age <= 55,
+                        "must fall back to the ~40s line, got {}".format(age))
+
+    def test_corrupt_and_nondict_lines_tolerated(self):
+        """A truncated/corrupt JSON line and a non-dict JSON line that
+        both slip past the substring pre-filter must be skipped, not
+        crash — the reader still finds the valid assistant line."""
+        from claude_statusline.sessions import get_last_assistant_timestamp_ms
+        # Write raw so we can inject malformed lines the JSON helper
+        # wouldn't produce.
+        f = tempfile.NamedTemporaryFile(
+            mode="w", encoding="utf-8", suffix=".jsonl",
+            delete=False, newline="", dir=self._test_dir,
+        )
+        f.write(json.dumps({
+            "type": "assistant",
+            "message": {"role": "assistant", "content": []},
+            "timestamp": self._iso(25)}) + "\n")
+        # Non-dict JSON array carrying both pre-filter substrings.
+        f.write('["timestamp", "assistant"]\n')
+        # Truncated object with both substrings — json.loads must raise.
+        f.write('{"timestamp": "2026-01-01T00:00:00.000Z", "assistant"\n')
+        f.close()
+        self._created_paths.append(f.name)
+        ms = get_last_assistant_timestamp_ms(f.name)
+        self.assertIsNotNone(ms)
+        age = time.time() - ms / 1000.0
+        self.assertTrue(15 <= age <= 40,
+                        "must skip garbage and find the ~25s line, got {}".format(age))
+
+    def test_cached_miss_sentinel(self):
+        """A cache MISS (no assistant message) is stored as the
+        {"ts": None} sentinel so a subsequent render answers None from
+        cache instead of re-tailing the file — the branch that avoids
+        re-reading on every render during a long user-only pause."""
+        from claude_statusline.sessions import get_last_assistant_timestamp_ms
+        path = self._write_transcript([
+            {"type": "user", "message": {"role": "user", "content": "hi"},
+             "timestamp": self._iso(5)},
+        ])
+        self.assertIsNone(get_last_assistant_timestamp_ms(path))
+        # Now append a valid assistant line, but the miss is cached for
+        # 5s — the second call must STILL return None (proving it read
+        # the sentinel, not the freshly-appended line).
+        with open(path, "a", encoding="utf-8", newline="") as fh:
+            fh.write(json.dumps({
+                "type": "assistant",
+                "message": {"role": "assistant", "content": []},
+                "timestamp": self._iso(1)}) + "\n")
+        self.assertIsNone(get_last_assistant_timestamp_ms(path),
+                          "miss sentinel must suppress the re-read within TTL")
+
+    def test_invalid_and_nonstring_paths(self):
+        from claude_statusline.sessions import get_last_assistant_timestamp_ms
+        for bad in (None, "", 123, [], {}, "relative/path.jsonl"):
+            self.assertIsNone(get_last_assistant_timestamp_ms(bad),
+                "path {!r} must return None".format(bad))
+
+    def test_path_outside_claude_dir_rejected(self):
+        """Defense-in-depth: a transcript path resolving outside
+        ~/.claude/ must be rejected even if the file exists."""
+        from claude_statusline.sessions import get_last_assistant_timestamp_ms
+        outside = tempfile.NamedTemporaryFile(
+            mode="w", suffix=".jsonl", delete=False)
+        outside.write(json.dumps(
+            {"role": "assistant", "timestamp": self._iso(5)}) + "\n")
+        outside.close()
+        try:
+            self.assertIsNone(get_last_assistant_timestamp_ms(outside.name))
+        finally:
+            os.remove(outside.name)
+
+    def test_missing_file_returns_none(self):
+        from claude_statusline.sessions import get_last_assistant_timestamp_ms
+        ghost = os.path.join(self._test_dir, "does-not-exist.jsonl")
+        self.assertIsNone(get_last_assistant_timestamp_ms(ghost))
+
+    def test_empty_file_returns_none(self):
+        from claude_statusline.sessions import get_last_assistant_timestamp_ms
+        path = self._write_transcript([])  # zero lines → empty file
+        self.assertIsNone(get_last_assistant_timestamp_ms(path))
+
+    def test_result_is_cached(self):
+        """Second call within the TTL returns the cached value even if
+        the file is deleted underneath us."""
+        from claude_statusline.sessions import get_last_assistant_timestamp_ms
+        path = self._write_transcript([
+            {"role": "assistant", "timestamp": self._iso(10)},
+        ])
+        first = get_last_assistant_timestamp_ms(path)
+        self.assertIsNotNone(first)
+        os.remove(path)
+        # File gone, but the 5s cache should still answer.
+        second = get_last_assistant_timestamp_ms(path)
+        self.assertEqual(first, second)
+
+
+class TestCacheAgeSection(unittest.TestCase):
+    """End-to-end `cache_age` section rendering: shows time since the
+    last assistant turn, warns past the ~5-min prompt-cache TTL, and
+    hides on every degrade path (no transcript, no timestamp, future
+    timestamp)."""
+
+    def _plain(self, output):
+        return re.sub(r"\x1b\[[0-9;]*m", "", output)
+
+    def _write_transcript(self, secs_ago):
+        from claude_statusline import sessions as sessions_mod
+        os.makedirs(sessions_mod._CLAUDE_DIR, exist_ok=True)
+        d = tempfile.mkdtemp(
+            prefix="claude-status-cacheage-r-", dir=sessions_mod._CLAUDE_DIR)
+        self._dirs.append(d)
+        path = os.path.join(d, "t.jsonl")
+        ts = time.strftime(
+            "%Y-%m-%dT%H:%M:%S.000Z", time.gmtime(time.time() - secs_ago))
+        with open(path, "w", encoding="utf-8", newline="") as f:
+            f.write(json.dumps(
+                {"type": "assistant",
+                 "message": {"role": "assistant", "content": []},
+                 "timestamp": ts}) + "\n")
+        return path
+
+    def setUp(self):
+        import shutil as shutil_mod
+        import claude_statusline.cli as cli_mod
+        from claude_statusline import sessions as sessions_mod
+        self._shutil_mod = shutil_mod
+        self._cli_mod = cli_mod
+        self._dirs = []
+        self._orig_line2 = THEMES["default"]["line2"]
+        self._orig_branch = cli_mod.get_branch
+        cli_mod.get_branch = lambda: "main"
+        THEMES["default"]["line2"] = ["cache_age", "branch"]
+        # Wide COLUMNS so the compact-droppable cache_age isn't shed by
+        # the responsive layout (it lives in _COMPACT_DROP).
+        self._orig_cols = os.environ.get("COLUMNS")
+        os.environ["COLUMNS"] = "300"
+        # Clear the cache_age cache each test (5s TTL cross-contamination).
+        try:
+            cache_dir = sessions_mod._cache_dir()
+            if os.path.isdir(cache_dir):
+                for name in os.listdir(cache_dir):
+                    if name.startswith("cache_age_ts_"):
+                        os.remove(os.path.join(cache_dir, name))
+        except OSError:
+            pass
+
+    def tearDown(self):
+        THEMES["default"]["line2"] = self._orig_line2
+        self._cli_mod.get_branch = self._orig_branch
+        if self._orig_cols is None:
+            os.environ.pop("COLUMNS", None)
+        else:
+            os.environ["COLUMNS"] = self._orig_cols
+        for d in self._dirs:
+            self._shutil_mod.rmtree(d, ignore_errors=True)
+
+    def _render(self, data):
+        return self._plain(self._cli_mod.render(data, "default"))
+
+    def test_renders_recent_age(self):
+        # ~90s ago. Assert a tolerance band, not an exact string: the
+        # fixture floors the timestamp to the whole second and the age
+        # is recomputed against the wall clock at render time, so a
+        # loaded machine can legitimately read 1m30s or 1m31s. An exact
+        # "1m30s" assertion would flake (determinism is a project rule).
+        path = self._write_transcript(90)
+        out = self._render({"git_branch": "main", "transcript_path": path})
+        m = re.search(r"cache_age:1m(\d{2})s", out)
+        self.assertIsNotNone(m, out)
+        self.assertTrue(29 <= int(m.group(1)) <= 32,
+                        "expected ~1m30s, got {}".format(m.group(0)))
+
+    def test_seconds_only_format(self):
+        path = self._write_transcript(12)
+        out = self._render({"git_branch": "main", "transcript_path": path})
+        m = re.search(r"cache_age:(\d+)s", out)
+        self.assertIsNotNone(m, out)
+        self.assertTrue(8 <= int(m.group(1)) <= 20)
+
+    def test_warn_color_past_ttl(self):
+        """Past ~5 min the chip uses the warn color (YELLOW); under it,
+        the muted default (BRIGHT_BLACK)."""
+        cold = self._cli_mod.render(
+            {"git_branch": "main", "transcript_path": self._write_transcript(400)},
+            "default")
+        self.assertIn(YELLOW, cold)
+        # Fresh cache dir state for the warm render.
+        self.tearDown(); self.setUp()
+        warm = self._cli_mod.render(
+            {"git_branch": "main", "transcript_path": self._write_transcript(30)},
+            "default")
+        self.assertIn("cache_age:", self._plain(warm))
+        # Warm render must NOT carry the warn (YELLOW) color and MUST
+        # use the muted default (BRIGHT_BLACK). Asserting both directions
+        # pins the threshold: a regression that always emitted the warn
+        # color would still pass a mere presence check on the warm side.
+        # Safe because this isolated line2 (cache_age + branch, branch is
+        # GREEN, no cost data) has no other YELLOW source.
+        self.assertNotIn(YELLOW, warm)
+        self.assertIn(BRIGHT_BLACK, warm)
+
+    def test_hidden_without_transcript(self):
+        out = self._render({"git_branch": "main"})
+        self.assertNotIn("cache_age", out)
+
+    def test_hidden_when_no_assistant_message(self):
+        from claude_statusline import sessions as sessions_mod
+        os.makedirs(sessions_mod._CLAUDE_DIR, exist_ok=True)
+        d = tempfile.mkdtemp(dir=sessions_mod._CLAUDE_DIR)
+        self._dirs.append(d)
+        path = os.path.join(d, "t.jsonl")
+        with open(path, "w", encoding="utf-8", newline="") as f:
+            f.write(json.dumps(
+                {"role": "user", "timestamp": "2026-01-01T00:00:00.000Z"}) + "\n")
+        out = self._render({"git_branch": "main", "transcript_path": path})
+        self.assertNotIn("cache_age", out)
+
+    def test_future_timestamp_hidden(self):
+        """A future-dated last message (clock skew) yields a negative
+        age; the section hides rather than render `cache_age:-3s`."""
+        path = self._write_transcript(-120)  # 2 minutes in the FUTURE
+        out = self._render({"git_branch": "main", "transcript_path": path})
+        self.assertNotIn("cache_age", out)
+
+    def test_bad_path_hidden_no_crash(self):
+        out = self._render({"git_branch": "main", "transcript_path": "/etc/passwd"})
+        self.assertNotIn("cache_age", out)
+
+    def test_cache_age_is_compact_droppable(self):
+        from claude_statusline.cli import (
+            _COMPACT_DROP, _NARROW_DROP, _FIT_DROP_PRIORITY)
+        self.assertIn("cache_age", _COMPACT_DROP)
+        self.assertIn("cache_age", _NARROW_DROP)
+        self.assertIn("cache_age", _FIT_DROP_PRIORITY)
 
 
 class TestCostBreakdownSection(unittest.TestCase):


### PR DESCRIPTION
## Summary

Adds an opt-in `cache_age` section that renders `cache_age:4m12s` — the wall-clock time since the last assistant turn. It's a cue for how long a long-running task has been going and, in particular, whether Anthropic's ~5-minute prompt cache is still warm. Past the cache TTL (5 min) the chip switches to a **warning color** to flag that the cache has likely gone cold; under it, a muted default.

Closes #92.

## What it reads

The age is derived from the `timestamp` field of the most recent assistant message in `transcript_path` — the same stdin-provided field the existing `activity` section already tail-reads. **No new stdin dependency, no undocumented-file parsing.**

## Implementation notes

- **Reuses the proven transcript reader.** `get_last_assistant_timestamp_ms()` mirrors `get_session_activity_count()`'s defense-in-depth: `realpath` validation under `~/.claude/` before any read, a single 64 KiB tail read, and TTL caching. No 1 MiB retry is needed here — the newest assistant message is always at EOF (unlike the activity reader, which walks back to a possibly-distant *user* message).
- **Live-to-the-second despite caching.** Caches the *timestamp* (not the derived age) for 5s; the renderer recomputes the age against the current clock every render. A cache *miss* is cached as a `{"ts": None}` sentinel so a long user-only pause doesn't re-tail the file every render.
- **Clock-skew safe.** A future-dated last message yields a negative age; the section hides rather than render a nonsense `cache_age:-3s`.
- **Python 3.8+ safe parse.** `_parse_iso8601_ms()` swaps a trailing `Z` for `+00:00` before `datetime.fromisoformat()` — required for the project's 3.8–3.10 floor, where `fromisoformat` rejects a bare `Z`.
- **Degrades gracefully.** Every error path (invalid/non-string path, path outside `~/.claude/`, missing/empty/unreadable file, no assistant message, unparseable timestamp) returns `None` → section hidden, never a crash.

## Also

- `--doctor` gains a `Cache age:` probe line (reports normal age, "no assistant timestamp in tail window", or the future-dated "clock skew — section hidden" case) alongside the existing `Activity:`/`Parse:` transcript diagnostics.
- `cache_age` added to `_COMPACT_DROP` so it sheds before essential sections under width pressure. The bar/tokens/cost/branch identity is never dropped.
- README feature table and CHANGELOG updated; version bumped 0.8.1 → 0.9.0.

## Testing

Pure stdlib, no dependency changes. **589 tests pass** (+25 new): ISO-8601 parser edge cases, the tail extractor with path-validation / caching / schema-fallback / corrupt-line resilience, end-to-end render including the warn threshold and future-timestamp hiding, the cached-miss sentinel, and the `--doctor` probe. Timing-sensitive tests use tolerance bands (not exact-second assertions) and were loop-verified 15× with zero flakes.

## Review

Reviewed by all four PR-review agents (code-reviewer, test-analyzer, silent-failure-hunter, comment-analyzer). Code-review and silent-failure passes were clean; the comment-analyzer flagged one inaccurate docstring (fixed) and the test-analyzer flagged six coverage gaps (all addressed — the +4 tests above the original set).