### PR TITLE
feat: cost_rate section (~$/hr projection) + numeric-input hardening

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,30 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.11.0] - 2026-07-09
+
+### Added
+
+- **`cost_rate` section** — renders `~$3.6/hr`, the session's projected cost per hour, from fields already on stdin (`cost.total_cost_usd` / `cost.total_duration_ms`). Pure arithmetic: no new data sources, no price tables, no vendor pricing knowledge (the cost field already reflects whatever pricing applies). Opt-in via custom theme, matching the `thinking` / `pr` / `cache_age` rollout.
+
+  - **Session-average by design** — total cost over total wall-clock time, *including idle*. It answers "what is this session costing per hour of being open", not "what would the current burst cost if sustained". A windowed recent-activity rate needs cached samples and is deliberately deferred.
+  - **The `~` prefix marks it as a projection**, not a bill — pinned by a test so a refactor can't silently turn the chip into a bill-looking number.
+  - **Hidden whenever the projection would be meaningless**: missing/garbage/NaN/Infinity inputs, zero or negative cost, sessions under one minute (`_COST_RATE_MIN_DURATION_MS` — a session's first seconds extrapolate absurdly, e.g. a $0.05 startup burst over 8s "projects" to $22/hr), and rates below rendering resolution (< $0.0005/hr would show a zero-looking `0c/hr` chip for a positive cost).
+  - Reuses `fmt_cost` for the dollar formatting, so the rate renders with the same conventions as the cost section (cents under a penny, `$0.XX` under a dollar, one decimal under $10, whole dollars above).
+
+### Fixed
+
+- **Garbage `cost` / `duration` values could blank the whole statusline.** A malformed upstream value (`total_cost_usd: "abc"`) flowed raw into `fmt_cost`/`fmt_duration` and threw from inside `render()` — caught only by `main()`'s outer handler, which blanks the entire statusline (stderr note, empty stdout) instead of hiding one section. The money/time trio (`cost`, `duration`, `api_duration`) is now coerced through `_safe_num` at the `_normalize` chokepoint (the house pattern), so garbage becomes `None` and every consumer already treats `None` as "hide". Numeric strings (`"0.5"`) coerce and render normally (pinned end-to-end). A present-but-garbage value leaves a one-line stderr breadcrumb (`claude-status: ignoring non-numeric cost value`) so the old crash's diagnostic trail isn't lost to a silent hide; absent fields stay silent. Found by this release's own new-feature tests probing garbage inputs.
+
+- **`_safe_num` now guarantees a FINITE float or None.** Previously `float("nan")`/`float("inf")` passed through — and NaN is poison downstream: every comparison is False, so it sails through threshold checks and detonates later inside a formatter's `int()`. `json.loads` accepts bare `NaN`/`Infinity`, so this was reachable from stdin. All existing `_safe_num` call sites treat `None` as "hide/skip", so the tightened contract is strictly safer; the one pre-existing explicit `isfinite` guard (cost-category filtering) is retained as documented defense-in-depth. Two concrete crashes and one lie this closes:
+  - `rate_limits.five_hour.resets_at: Infinity` previously reached `fmt_countdown`'s `int()` → `OverflowError` (not in its except tuple) → whole line blanked. Now hidden. `fmt_countdown` also gained `OverflowError` in its own except tuple so the hole stays shut even if `_safe_num` ever loosens.
+  - `used_percentage: NaN` previously sailed past the `>= 1e6` sanity cap (NaN comparisons are all False) into `min(100, nan)` → Python returns **100** → the statusline rendered a false danger-red `5h:100%` for garbage input. Now hidden — a masked wrong output replaced by an honest absence.
+
+### Notes
+
+- No changes to any default theme — `cost_rate` must be added to a custom theme's line list to appear. No rendering changes for existing sections beyond the garbage-input hardening above (which only affects payloads that previously crashed the render).
+- 624 tests pass (+21: formatter gates including boundary/garbage/non-finite/sub-resolution matrices, exact-value pin at the 60s gate, end-to-end section rendering with the tilde pin, droppable membership, `_safe_num` finite-contract pins, garbage cost AND duration/latency/speed render coverage, and the stringified-numerics e2e pin). Pure stdlib, zero dependencies, as always.
+
 ## [0.10.0] - 2026-07-09
 
 1M-context readiness release. Claude Code's default model now ships a

--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ The setup wizard walks you through theme selection, budget configuration, and in
 | Cost | `$0.73` | Session cost in real-time — cents for small, dollars for large |
 | Budget | `$0.73/$10` | Color-coded daily budget tracker (green/yellow/red) |
 | Burn Rate | `burn:37K/min` | Tokens/min consumption — unique to claude-status |
+| Cost Rate | `~$3.6/hr` | Projected session cost per hour (session average, includes idle time; the `~` marks it as a projection). Hidden for sessions under a minute. Opt-in via custom theme. |
 | Rate Limits | `5h:34% 7d:18% ~2h` | API usage limits with reset countdown (Pro/Max only) |
 | Context Size | `(1M)` | Know if you're on a 200K or 1M context window |
 | Context Warning | `!CTX` | Bold red alert at 85%+ context usage |

--- a/claude_statusline/__init__.py
+++ b/claude_statusline/__init__.py
@@ -1,3 +1,3 @@
 """claude-status: Beautiful status line for Claude Code."""
 
-__version__ = "0.10.0"
+__version__ = "0.11.0"

--- a/claude_statusline/cli.py
+++ b/claude_statusline/cli.py
@@ -21,8 +21,8 @@ from .colors import (
     YELLOW, colorize,
 )
 from .formatters import (
-    fmt_burn_rate, fmt_cache_pct, fmt_cost, fmt_countdown, fmt_duration,
-    fmt_lines, fmt_speed, fmt_tokens,
+    fmt_burn_rate, fmt_cache_pct, fmt_cost, fmt_cost_rate, fmt_countdown,
+    fmt_duration, fmt_lines, fmt_speed, fmt_tokens,
 )
 from .git import (
     get_branch, get_git_extras, get_git_state,
@@ -115,13 +115,22 @@ def _first(*vals):
 
 
 def _safe_num(val):
-    """Coerce to float or return None. Prevents crashes on non-numeric input."""
+    """Coerce to a FINITE float or return None.
+
+    Prevents crashes on non-numeric input. NaN and Infinity are
+    rejected too (json.loads accepts both as bare literals): every
+    consumer treats the return value as render-ready, and NaN in
+    particular is poison downstream — all comparisons are False, so it
+    sails through threshold checks and only blows up later inside a
+    formatter's int(). "Safe" means finite.
+    """
     if val is None:
         return None
     try:
-        return float(val)
+        num = float(val)
     except (TypeError, ValueError):
         return None
+    return num if math.isfinite(num) else None
 
 
 def _osc8_link(url, text):
@@ -191,9 +200,37 @@ def _normalize(data):
     # of a dict.
     cost_obj = data.get("cost")
     cost_obj = cost_obj if isinstance(cost_obj, dict) else {}
-    out["cost"] = _first(cost_obj.get("total_cost_usd"), data.get("cost_usd"))
-    out["duration"] = _first(cost_obj.get("total_duration_ms"), data.get("session_duration_ms"))
-    out["api_duration"] = _first(cost_obj.get("total_api_duration_ms"), data.get("api_duration_ms"))
+    # _safe_num on the money/time trio: a stringified or garbage value
+    # (e.g. `total_cost_usd: "abc"` from a malformed upstream) would
+    # otherwise flow raw into fmt_cost/fmt_duration and throw from
+    # inside render() — caught only by main()'s outer fallback, which
+    # blanks the whole statusline instead of hiding one section.
+    # Coercing here (same chokepoint pattern as by_category below)
+    # turns garbage into None, which every consumer already treats as
+    # "hide". Numeric strings ("0.5") coerce and render normally.
+    #
+    # The stderr breadcrumb preserves diagnosability: the old crash at
+    # least left "render error: ..." on stderr (visible in Claude
+    # Code's debug logs), whereas a silent hide would leave a user
+    # debugging "my cost chip vanished" with nothing. present-but-
+    # garbage is the ONLY case that notes; absent stays silent.
+    def _num_or_note(field, raw):
+        num = _safe_num(raw)
+        if num is None and raw is not None:
+            print(
+                "claude-status: ignoring non-numeric {} value".format(field),
+                file=sys.stderr,
+            )
+        return num
+
+    out["cost"] = _num_or_note(
+        "cost", _first(cost_obj.get("total_cost_usd"), data.get("cost_usd")))
+    out["duration"] = _num_or_note(
+        "duration",
+        _first(cost_obj.get("total_duration_ms"), data.get("session_duration_ms")))
+    out["api_duration"] = _num_or_note(
+        "api_duration",
+        _first(cost_obj.get("total_api_duration_ms"), data.get("api_duration_ms")))
     out["lines_added"] = _first(cost_obj.get("total_lines_added"), data.get("lines_added"))
     out["lines_removed"] = _first(cost_obj.get("total_lines_removed"), data.get("lines_removed"))
 
@@ -217,14 +254,15 @@ def _normalize(data):
             if not isinstance(k, str):
                 continue
             num = _safe_num(v)
-            # math.isfinite() rejects nan and ±inf. Without it,
-            # a stringified `"inf"` upstream would coerce via
-            # _safe_num to float('inf'), pass `num > 0`, and the
-            # sum-fallback path would then render an infinite total.
-            # Pre-v0.6.1 the renderer's isinstance filter would have
-            # rejected the string `"inf"` before coercion; the new
-            # coerce-on-store contract makes the explicit isfinite
-            # guard load-bearing here at the boundary.
+            # Defense-in-depth: since v0.11.0 _safe_num itself rejects
+            # nan/±inf (returns None), so this explicit isfinite is
+            # redundant — but it stays because this exact hole (a
+            # stringified `"inf"` coercing to float('inf'), passing
+            # `num > 0`, and rendering an infinite total via the
+            # sum-fallback) was opened and had to be re-guarded within
+            # a single release (v0.6.1, caught pre-release), and the
+            # local guard pins the contract at this boundary even if
+            # _safe_num's semantics ever loosen again.
             if num is None or not math.isfinite(num) or num <= 0:
                 continue
             sane_categories[k] = float(num)
@@ -766,6 +804,20 @@ def _render_sections_named(n, order, theme):
                     colorize("speed:", tc["label"]) + colorize(speed_str, spc)
                 )
 
+        elif section == "cost_rate":
+            # Projected session cost per hour, rendered "~$3.6/hr" —
+            # the leading tilde signals "projection", not a bill.
+            # Session-average including idle time; fmt_cost_rate owns
+            # every hide-gate (missing/garbage/NaN inputs, zero cost,
+            # sub-minute sessions), so an empty string means hide.
+            # Color falls through via _first() so a theme setting
+            # `cost_rate: null` degrades to CYAN rather than crashing
+            # colorize().
+            rate_str = fmt_cost_rate(cost, duration)
+            if rate_str:
+                crc = _first(tc.get("cost_rate"), CYAN)
+                sections.append(colorize("~" + rate_str, crc))
+
         elif section == "lines":
             lines_str = fmt_lines(lines_added, lines_removed)
             if lines_str:
@@ -799,13 +851,13 @@ def _render_sections_named(n, order, theme):
             # "(1M)" rather than "(1000K)". One formatting path for every
             # token-shaped number keeps K/M suffix rules consistent —
             # the old integer-division label predates 1M windows
-            # becoming the default. _safe_num rejects a non-numeric
-            # window size, and isfinite rejects NaN/Infinity (both are
-            # valid to Python's json.loads and NaN is truthy, so it
-            # would otherwise reach int() and crash — renderers must
-            # never crash on external JSON).
+            # becoming the default. _safe_num rejects non-numeric AND
+            # non-finite window sizes (NaN/Infinity are valid to
+            # Python's json.loads; _safe_num guarantees a finite float
+            # or None since v0.11.0), so nothing garbage reaches int()
+            # — renderers must never crash on external JSON.
             cs = _safe_num(context_size)
-            if cs and math.isfinite(cs):
+            if cs:
                 sections.append(colorize(
                     "({})".format(fmt_tokens(int(cs))), BRIGHT_BLACK))
 
@@ -1161,8 +1213,8 @@ _COMPACT_DROP = [
     "git_extras", "version", "cc_version", "clock", "worktree",
     "sessions", "tools", "activity", "cache_age", "latency", "context_size",
     "session_name", "rate_limits", "output_style", "added_dirs", "effort",
-    "git_worktree", "speed", "git_state", "commit_age", "cost_breakdown",
-    "pr", "thinking",
+    "git_worktree", "speed", "cost_rate", "git_state", "commit_age",
+    "cost_breakdown", "pr", "thinking",
 ]
 _NARROW_DROP = _COMPACT_DROP + [
     "cache", "burn", "lines", "budget", "agent", "model",

--- a/claude_statusline/formatters.py
+++ b/claude_statusline/formatters.py
@@ -1,6 +1,15 @@
 """Formatting functions for tokens, cost, duration, and burn rate."""
 
+import math
 import time
+
+# Minimum session duration before a $/hr projection is shown. A
+# session's first seconds extrapolate absurdly (a $0.05 startup burst
+# over 8s "projects" to $22/hr), so the cost_rate section stays hidden
+# until the average has something real behind it. One minute is the
+# smallest window where the session-average starts being meaningful;
+# it also matches the intuition that a projection needs history.
+_COST_RATE_MIN_DURATION_MS = 60_000
 
 
 def fmt_tokens(n):
@@ -99,6 +108,52 @@ def fmt_burn_rate(total_tokens, duration_ms):
     return "{}/min".format(fmt_tokens(int(rate)))
 
 
+def fmt_cost_rate(cost, duration_ms):
+    """Project session cost to dollars per hour: "$3.6/hr".
+
+    Session-average by design: total cost over total wall-clock time,
+    INCLUDING idle time — this answers "what is this session costing
+    me per hour of it being open", not "what would the current burst
+    cost if sustained". (A windowed recent-activity rate is a possible
+    future refinement; it needs cached samples and is deliberately out
+    of scope here.)
+
+    Returns "" (section hidden) when the projection would be
+    meaningless or the inputs are garbage:
+      - cost or duration missing / non-numeric / NaN / Infinity
+      - cost <= 0 (a zero session projects to $0/hr — noise)
+      - duration under _COST_RATE_MIN_DURATION_MS (early-session
+        extrapolation is absurd; see the constant's comment)
+      - rate below fmt_cost's rendering resolution (< $0.0005/hr),
+        which would show a zero-looking "0c/hr" chip for a positive
+        cost — same noise the zero gate exists to suppress
+
+    Reuses fmt_cost for the dollar formatting so rate and cost render
+    with identical conventions (cents under a penny, $0.XX under a
+    dollar, one decimal under $10, whole dollars above).
+    """
+    try:
+        c = float(cost)
+        d = float(duration_ms)
+    except (TypeError, ValueError):
+        return ""
+    if not (math.isfinite(c) and math.isfinite(d)):
+        return ""
+    if c <= 0 or d < _COST_RATE_MIN_DURATION_MS:
+        return ""
+    rate = c / (d / 3_600_000)
+    if not math.isfinite(rate):
+        return ""
+    # Below fmt_cost's rendering resolution the chip would read
+    # "0c/hr" — a zero-looking projection for a positive cost, which
+    # contradicts the "zero projection is noise" gate above. fmt_cost's
+    # cents branch shows one decimal, so anything under half of 0.1c
+    # (rate < $0.0005/hr) rounds to "0.0" and gets hidden instead.
+    if rate < 0.0005:
+        return ""
+    return fmt_cost(rate) + "/hr"
+
+
 def fmt_lines(added, removed):
     """Format lines changed in git-diff style."""
     parts = []
@@ -136,7 +191,13 @@ def fmt_countdown(resets_at_ms):
     try:
         now_ms = int(time.time() * 1000)
         remaining_ms = int(resets_at_ms) - now_ms
-    except (TypeError, ValueError):
+    except (TypeError, ValueError, OverflowError):
+        # OverflowError: int(float("inf")). Since v0.11.0 _safe_num
+        # rejects non-finite values upstream so inf can't reach here
+        # from stdin — but this local catch pins the hole shut
+        # independently, so a future loosening of _safe_num can't
+        # silently reintroduce a whole-line crash. (Same tuple as
+        # _clean_pr_number's handler in cli.py.)
         return ""
     if remaining_ms < 1000:
         return ""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "claude-status"
-version = "0.10.0"
+version = "0.11.0"
 description = "Beautiful, informative status line for Claude Code — zero dependencies, cross-platform"
 readme = "README.md"
 license = {text = "MIT"}

--- a/tests/test_all.py
+++ b/tests/test_all.py
@@ -353,6 +353,55 @@ class TestFmtBurnRate(unittest.TestCase):
         self.assertEqual(fmt_burn_rate(1000, 0), "?")
 
 
+class TestFmtCostRate(unittest.TestCase):
+    """fmt_cost_rate projects session cost to $/hr ("$3.6/hr").
+    Empty string means "hide the section" — every meaningless or
+    garbage input must land there, never an exception."""
+
+    def test_normal(self):
+        # $0.73 over 12m05s -> ~$3.62/hr -> fmt_cost one-decimal form
+        from claude_statusline.formatters import fmt_cost_rate
+        self.assertEqual(fmt_cost_rate(0.73, 725_000), "$3.6/hr")
+
+    def test_exact_hour(self):
+        from claude_statusline.formatters import fmt_cost_rate
+        self.assertEqual(fmt_cost_rate(5.0, 3_600_000), "$5.0/hr")
+
+    def test_cheap_session_cents(self):
+        """Sub-penny rates reuse fmt_cost's cents form."""
+        from claude_statusline.formatters import fmt_cost_rate
+        self.assertEqual(fmt_cost_rate(0.0002, 120_000), "0.6c/hr")
+
+    def test_big_rate_whole_dollars(self):
+        from claude_statusline.formatters import fmt_cost_rate
+        self.assertEqual(fmt_cost_rate(12.0, 3_600_000), "$12/hr")
+
+    def test_sub_minute_hidden(self):
+        """Early-session extrapolation is absurd; hidden under 60s."""
+        from claude_statusline.formatters import fmt_cost_rate
+        self.assertEqual(fmt_cost_rate(0.50, 59_999), "")
+
+    def test_exactly_at_gate_shows(self):
+        """Exact value pinned: $0.50 over exactly 1 minute is $30/hr.
+        Pins both the arithmetic and the >= (not >) gate direction."""
+        from claude_statusline.formatters import fmt_cost_rate
+        self.assertEqual(fmt_cost_rate(0.50, 60_000), "$30/hr")
+
+    def test_zero_and_negative_cost_hidden(self):
+        from claude_statusline.formatters import fmt_cost_rate
+        self.assertEqual(fmt_cost_rate(0, 3_600_000), "")
+        self.assertEqual(fmt_cost_rate(-1.0, 3_600_000), "")
+
+    def test_missing_and_garbage_hidden(self):
+        from claude_statusline.formatters import fmt_cost_rate
+        for cost, dur in ((None, None), (None, 100_000), (1.0, None),
+                          ("abc", 100_000), (1.0, "xyz"), ({}, []),
+                          (float("nan"), 100_000), (1.0, float("nan")),
+                          (float("inf"), 100_000), (1.0, float("inf"))):
+            self.assertEqual(fmt_cost_rate(cost, dur), "",
+                "cost={!r} dur={!r} must hide".format(cost, dur))
+
+
 class TestFmtLines(unittest.TestCase):
     def test_both(self):
         self.assertEqual(fmt_lines(10, 5), "+10 -5")
@@ -502,6 +551,168 @@ class TestContextSizeLabel(unittest.TestCase):
         out = self._render_ctx(float("inf"))
         self.assertIn("main", out)
         self.assertNotIn("inf", out.lower())
+
+
+class TestCostRateSection(unittest.TestCase):
+    """End-to-end `cost_rate` section: "~$3.6/hr" projection from
+    cost.total_cost_usd / cost.total_duration_ms. Opt-in via custom
+    theme; hidden on every degrade path (fmt_cost_rate owns the gates,
+    these tests pin the section wiring)."""
+
+    def _plain(self, s):
+        return re.sub(r"\x1b\[[0-9;]*m", "", s)
+
+    def _render(self, cost_obj):
+        import claude_statusline.cli as cli_mod
+        orig_line2 = THEMES["default"]["line2"]
+        orig_branch = cli_mod.get_branch
+        cli_mod.get_branch = lambda: "main"
+        try:
+            THEMES["default"]["line2"] = ["cost_rate", "branch"]
+            data = {"git_branch": "main"}
+            if cost_obj is not _SENTINEL:
+                data["cost"] = cost_obj
+            return self._plain(cli_mod.render(data, "default"))
+        finally:
+            THEMES["default"]["line2"] = orig_line2
+            cli_mod.get_branch = orig_branch
+
+    def test_renders_projection(self):
+        out = self._render(
+            {"total_cost_usd": 0.73, "total_duration_ms": 725_000})
+        self.assertIn("~$3.6/hr", out)
+
+    def test_tilde_prefix(self):
+        """The tilde marks it as a projection — pin it so a refactor
+        doesn't silently turn the chip into a bill-looking number.
+        The startswith check discriminates properly: it fails for a
+        missing tilde AND for a doubled one, unlike a substring
+        assertion (\"~~$5.0/hr\" would still contain \"~$5.0/hr\")."""
+        out = self._render(
+            {"total_cost_usd": 5.0, "total_duration_ms": 3_600_000})
+        self.assertIn("~$5.0/hr", out)
+        chip_lines = [l for l in out.split("\n") if "/hr" in l]
+        self.assertTrue(chip_lines and chip_lines[0].startswith("~$5.0/hr"),
+                        "chip must start with exactly one tilde: {!r}".format(chip_lines))
+
+    def test_hidden_when_cost_absent(self):
+        self.assertNotIn("/hr", self._render(_SENTINEL))
+
+    def test_hidden_sub_minute_session(self):
+        out = self._render(
+            {"total_cost_usd": 0.50, "total_duration_ms": 30_000})
+        self.assertNotIn("/hr", out)
+
+    def test_hidden_zero_cost(self):
+        out = self._render(
+            {"total_cost_usd": 0, "total_duration_ms": 3_600_000})
+        self.assertNotIn("/hr", out)
+
+    def test_garbage_cost_object_no_crash(self):
+        """cost as a bare string (older schemas / malformed upstream)
+        must hide the section, not crash — _normalize's isinstance
+        guard plus _safe_num coercion both stand in the way. NaN and
+        Infinity (valid json.loads literals) are included: _safe_num
+        rejects non-finite values at the chokepoint."""
+        for garbage in ("expensive", 42, ["x"], {"total_cost_usd": "abc"},
+                        {"total_cost_usd": float("nan"),
+                         "total_duration_ms": 100_000},
+                        {"total_cost_usd": 1.0,
+                         "total_duration_ms": float("inf")}):
+            out = self._render(garbage)
+            self.assertNotIn("/hr", out,
+                "cost={!r} must not render a rate".format(garbage))
+            self.assertIn("main", out)
+
+    def test_cost_rate_is_compact_droppable(self):
+        from claude_statusline.cli import (
+            _COMPACT_DROP, _NARROW_DROP, _FIT_DROP_PRIORITY)
+        self.assertIn("cost_rate", _COMPACT_DROP)
+        self.assertIn("cost_rate", _NARROW_DROP)
+        self.assertIn("cost_rate", _FIT_DROP_PRIORITY)
+
+    def test_subpenny_rate_hidden_not_zero_chip(self):
+        """A positive-but-below-resolution rate must hide rather than
+        render a zero-looking "~0c/hr" chip (contradicts the zero-is-
+        noise gate). $0.02 over ~116 days projects under 0.1c/hr."""
+        from claude_statusline.formatters import fmt_cost_rate
+        self.assertEqual(fmt_cost_rate(0.02, 10_000_000_000), "")
+        # Just above the resolution floor still shows.
+        self.assertEqual(fmt_cost_rate(0.0006, 3_600_000), "0.1c/hr")
+
+    def test_garbage_duration_sections_no_crash(self):
+        """Garbage total_duration_ms / total_api_duration_ms rendered
+        through their ACTUAL consuming sections (duration, latency,
+        speed) — pre-v0.11.0 fmt_duration("xyz") crashed render().
+        The cost_rate-only fixtures above never exercise these."""
+        import claude_statusline.cli as cli_mod
+        orig_line2 = THEMES["default"]["line2"]
+        orig_branch = cli_mod.get_branch
+        cli_mod.get_branch = lambda: "main"
+        try:
+            THEMES["default"]["line2"] = [
+                "duration", "latency", "speed", "branch"]
+            out = self._plain(cli_mod.render({
+                "git_branch": "main",
+                "cost": {"total_duration_ms": "xyz",
+                         "total_api_duration_ms": ["nope"]},
+            }, "default"))
+            self.assertIn("main", out)
+            self.assertNotIn("xyz", out)
+        finally:
+            THEMES["default"]["line2"] = orig_line2
+            cli_mod.get_branch = orig_branch
+
+    def test_stringified_numerics_render_normally(self):
+        """CHANGELOG claim pinned e2e: numeric strings coerce and
+        render — "0.5" cost shows $0.50, "725000" duration shows
+        12m05s. Guards against a future over-tightening of _safe_num
+        (e.g. an isinstance gate) blanking string-emitting upstreams."""
+        import claude_statusline.cli as cli_mod
+        orig_line2 = THEMES["default"]["line2"]
+        orig_branch = cli_mod.get_branch
+        cli_mod.get_branch = lambda: "main"
+        try:
+            THEMES["default"]["line2"] = ["duration", "cost_rate", "branch"]
+            out = self._plain(cli_mod.render({
+                "git_branch": "main",
+                "cost": {"total_cost_usd": "0.5",
+                         "total_duration_ms": "725000"},
+            }, "default"))
+            self.assertIn("$0.50", out)      # cost section (line1)
+            self.assertIn("12m05s", out)     # duration section (line2)
+            # 0.5/(725s/3600s) = $2.48/hr; fmt_cost's one-decimal
+            # branch ROUNDS, so the chip reads $2.5, not $2.4.
+            self.assertIn("~$2.5/hr", out)
+        finally:
+            THEMES["default"]["line2"] = orig_line2
+            cli_mod.get_branch = orig_branch
+
+
+class TestSafeNumFinite(unittest.TestCase):
+    """_safe_num guarantees a FINITE float or None (v0.11.0). NaN in
+    particular is poison: every comparison is False, so it sails
+    through threshold checks and detonates later inside a formatter's
+    int(). "Safe" means finite — pinned here so a future refactor
+    can't quietly reopen the hole."""
+
+    def test_finite_passthrough(self):
+        from claude_statusline.cli import _safe_num
+        self.assertEqual(_safe_num(1.5), 1.5)
+        self.assertEqual(_safe_num("0.5"), 0.5)
+        self.assertEqual(_safe_num(0), 0.0)
+
+    def test_non_finite_rejected(self):
+        from claude_statusline.cli import _safe_num
+        for bad in (float("nan"), float("inf"), float("-inf"),
+                    "nan", "inf", "-inf", "Infinity", "NaN"):
+            self.assertIsNone(_safe_num(bad),
+                "_safe_num({!r}) must be None".format(bad))
+
+    def test_garbage_rejected(self):
+        from claude_statusline.cli import _safe_num
+        for bad in (None, "abc", [], {}, object()):
+            self.assertIsNone(_safe_num(bad))
 
 
 # ─── git.py ───────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Adds the opt-in **`cost_rate` section** — `~$3.6/hr`, the session's projected cost per hour, computed purely from fields already on stdin (`cost.total_cost_usd` / `cost.total_duration_ms`). No new data sources, no vendor price tables (the cost field already reflects whatever pricing applies).

- **Session-average by design** (includes idle time) — answers "what is this session costing per hour of being open." A windowed recent-activity rate is deliberately deferred (needs cached samples).
- **`~` prefix marks it a projection**, pinned by a discriminating test (catches missing *and* doubled tilde).
- **Hidden whenever meaningless**: garbage/NaN/Infinity inputs, zero/negative cost, sessions under 1 minute (early-session extrapolation is absurd), and sub-resolution rates that would render a zero-looking `0c/hr`.
- Opt-in via custom theme (no default-theme changes), sheds early under width pressure.

## Hardening (found by this feature's own garbage-input tests)

- **`cost`/`duration`/`api_duration` coerced via `_safe_num` at `_normalize`** — previously `total_cost_usd: "abc"` threw inside `render()` and blanked the *entire* statusline; now one section hides and a one-line stderr breadcrumb preserves the diagnostic trail (present-but-garbage notes; absent stays silent).
- **`_safe_num` now guarantees a finite float or None** — `json.loads` accepts bare `NaN`/`Infinity`, and both were live problems: NaN `used_percentage` rendered a **false danger-red `5h:100%`** (`min(100, nan) == 100` — verified), and Infinity `resets_at` **crashed the whole line** via an uncaught `OverflowError` in `fmt_countdown`. Both now hide honestly. `fmt_countdown` also catches `OverflowError` itself so the hole stays shut even if `_safe_num` ever loosens.

## Testing & review

- **624 tests pass (+21)**: formatter gate matrices (boundary/garbage/non-finite/sub-resolution), exact-value pin at the 60s gate, e2e rendering incl. stringified-numerics (`"0.5"` → `$0.50`) and garbage duration through the duration/latency/speed sections, `_safe_num` finite-contract pins, droppable membership.
- Reviewed by all four PR-review agents; every finding addressed (sub-resolution zero-chip gate, misfiled/duplicated test, dead-weight tilde assertion replaced with a discriminating one, two docstring/comment inaccuracies corrected, stderr breadcrumb added, `fmt_countdown` OverflowError pinned). The code-reviewer traced every consumer of the coerced trio and confirmed no behavioral regressions (int→float is observationally identical through all formatters).