### PR TITLE
feat: daily budget semantics — day-spend rollup across sessions (day:$X/$Y)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,40 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.12.0] - 2026-07-09
+
+### Changed — ⚠️ the `budget` section's meaning is fixed (and its label changes)
+
+- **The budget chip now compares TODAY'S spend — summed across all your sessions on this machine — against `daily_budget_usd`, and is labeled `day:$7.4/$10`.** Before v0.12.0 it compared only the *current session's* cost against the daily budget: five $3 sessions against a $10/day budget each showed a comfortable green $3.0/$10 while the day was actually at 150% of budget. The config key's own name (`daily_budget_usd`), the README ("daily budget tracker"), and the FAQ ("your daily limit") were always unanimous that the contract is daily; the display was the wrong half. The `day:` prefix is deliberate: it announces the change at the moment of upgrade and permanently disambiguates the chip from the adjacent per-session `cost` chip.
+
+  - **Escape hatch:** if you calibrated `daily_budget_usd` as a per-*session* ceiling under the old behavior, set `"budget_scope": "session"` in `~/.claude/claude-status-budget.json` — the chip reverts to the per-session comparison (no `day:` prefix).
+  - **Day-one note:** totals accumulate from the moment you upgrade; on the first day the chip may undercount sessions from earlier that morning.
+  - **Per machine:** the total is built from local session records; it will undercount your real bill if you also run Claude Code elsewhere. (Documented in the FAQ.)
+
+### Added
+
+- **Per-session daily spend ledger** — one small JSON file per (local day, session) in the user-scoped cache dir, storing the session's cumulative cost (monotonic via `max`) and an attribution base so a session spanning midnight contributes only its post-midnight growth to the new day. Whether a session "started today" is derived from `cost.total_duration_ms` (start ≈ now − duration): started-today sessions get full attribution (this is also what makes upgrade day honest — a mid-session upgrade shows the session's real spend, not $0); older sessions count growth only; missing duration falls back to growth-only (undercounts one turn, never overcounts).
+
+  The design went through two adversarial reviews **before implementation**; choices that trace directly to findings:
+  - **Writer-then-reader in one pass, no substitution rule** — an earlier draft's "substitute live cost if larger" compared a cumulative against a day-contribution (units mismatch) and would have re-inflated midnight-spanning sessions by their full prior-day spend.
+  - **Raw no-TTL ledger reads** (`_read_ledger`) — reusing the 30s-TTL cache reader would have re-captured the attribution base after every pause longer than 30 seconds, sawtoothing the day total toward zero.
+  - **No fallback mode.** The chip's meaning never switches: the live session's *contribution* (per the attribution rules above) is ALWAYS folded into the total — from its ledger file, or computed in memory when the session id is unusable, the write fails, or the ledger is skipped — so a chip labeled `day:` can never silently exclude the session in front of you, and never reverts to per-session semantics with an identical-looking label. When the ledger is empty, the total degrades to the live session's contribution alone: an honest lower bound.
+  - **Clamps both ends** — negative/garbage costs are clamped in the writer and contributions floored at 0 in the reader, so a garbage negative baseline can't manufacture phantom spend.
+  - **Documented, accepted limitations:** totals are per-machine; a temp-dir wipe mid-day permanently drops that day's *prior* spend (undercount only); a resumed session whose upstream counter jumps to a higher historical baseline mid-day over-attributes the jump to today (not detectable from stdin); two live processes sharing one session id can transiently regress each other's ledger entry via `max()` races (self-heals on the next write).
+
+- **`budget_scope` config key** — `"daily"` (default) or `"session"`, read from the existing `claude-status-budget.json` with the same 30s shared cache; unknown values fall through to daily. Reading uses `.get` with a default so a config dict cached by an older version (key absent) can't `KeyError` during the upgrade window.
+
+### Fixed
+
+- **Cache directory hardened to `0o700`** — the user-scoped cache dir name is predictable (md5 of the home path) and `exist_ok=True` would silently adopt a directory pre-created by another local user. That mattered less when the dir held tool counts; now that it holds per-session spend records, both are hardened best-effort: directories the user owns are repaired to `0o700`; a foreign-owned pre-created directory cannot be repaired (the chmod fails and is swallowed), which is why the ledger additionally refuses to operate in the shared-tempdir fallback. Created with `mode=0o700` and re-`chmod`ed if it already exists; no-op-equivalent on Windows where the temp dir is already per-user.
+
+### Notes
+
+- The ledger reuses the existing infrastructure end to end: atomic `tmp + os.replace` writes, the user-scoped cache dir, and the existing 2-day mtime cleanup — today's files are rewritten all day (fresh mtime) and age out naturally after the day passes. No new pruning code.
+- **`--demo` and the setup wizard stub the spend recorder** — an unstubbed preview render on a machine with a real budget config would have written the fake demo cost into the user's REAL daily ledger (monotonic max — it could not self-correct until midnight). Same class of fix at the test-suite level: `setUpModule` now redirects the entire cache dir to a throwaway location, so no test can ever write phantom spend into a maintainer's live chip (the #96 incident pattern, closed at the same chokepoint style).
+- **Garbage durations can't crash the render** — `time.localtime` raises `OverflowError`/`OSError` for epoch values outside time_t range (a duration like `9e18` ms is finite, so `_safe_num` passes it); the started-today classifier now catches these and degrades to the conservative base. Found by review, reproduced before fixing.
+- 655 tests (+31): attribution rules (started-today / midnight-spanning / missing-duration / in-memory no-sid variants), monotonicity, negative-clamp with the exact-value pin, corrupt/garbage/`.tmp`-leftover ledger files, day-boundary and midnight determinism via an injected noon clock, shared-sid interleave self-healing, shared-tempdir poisoning guard, unreachable-cache-dir degrade, garbage-duration crash regression, end-to-end chip rendering with color bands computed on the *total*, the scope escape hatch (unit AND through the real config-file parse), upgrade-day lower-bound, and the `0o700` create/repair pins (POSIX-only; skip on Windows, run on the Linux/macOS CI legs). 653 pass + 2 platform skips on Windows; all 655 on POSIX. Pure stdlib, zero dependencies, as always.
+
 ## [0.11.0] - 2026-07-09
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ The setup wizard walks you through theme selection, budget configuration, and in
 | Token Counts | `in:412K out:18K` | Human-readable (K/M) — no squinting at raw numbers |
 | Cache Hit Ratio | `cache:87%` | Of cacheable prompt input, how much actually hit the cache — close to 100% means cache-friendly prompts |
 | Cost | `$0.73` | Session cost in real-time — cents for small, dollars for large |
-| Budget | `$0.73/$10` | Color-coded daily budget tracker (green/yellow/red) |
+| Budget | `day:$7.4/$10` | Color-coded daily budget tracker (green/yellow/red). Sums today's spend across all sessions on this machine (v0.12.0+); set `"budget_scope": "session"` in the config for the old per-session comparison. |
 | Burn Rate | `burn:37K/min` | Tokens/min consumption — unique to claude-status |
 | Cost Rate | `~$3.6/hr` | Projected session cost per hour (session average, includes idle time; the `~` marks it as a projection). Hidden for sessions under a minute. Opt-in via custom theme. |
 | Rate Limits | `5h:34% 7d:18% ~2h` | API usage limits with reset countdown (Pro/Max only) |
@@ -285,7 +285,11 @@ Yes! Fully tested on Windows 11, macOS, and Linux across Python 3.8–3.14.
 Yes — use `--theme custom` with a `~/.claude/claude-status-theme.json` file. Override any color or layout from the built-in themes.
 
 **How does budget monitoring work?**
-Create `~/.claude/claude-status-budget.json` with `{"daily_budget_usd": 10.00}`. The cost indicator turns yellow at 70% and red at 90% of your daily limit.
+Create `~/.claude/claude-status-budget.json` with `{"daily_budget_usd": 10.00}`. The chip renders `day:$7.4/$10` — today's spend summed across all your sessions on this machine — turning yellow at 70% and red at 90% of your daily limit. Three things to know:
+
+- **Per machine.** The total comes from local session records, so it will undercount your real bill if you also run Claude Code on another computer.
+- **Accumulates from the moment you upgrade** to v0.12.0 — on the first day the total may miss sessions from earlier that morning.
+- **Prefer the old behavior?** Versions before v0.12.0 compared only the *current session's* cost against the daily budget. If you calibrated your number as a per-session ceiling, set `"budget_scope": "session"` in the same config file to keep that comparison (the chip then renders without the `day:` prefix).
 
 **What is burn rate?**
 Tokens consumed per minute. Helps you gauge how fast you're using context in a session.

--- a/claude_statusline/__init__.py
+++ b/claude_statusline/__init__.py
@@ -1,3 +1,3 @@
 """claude-status: Beautiful status line for Claude Code."""
 
-__version__ = "0.11.0"
+__version__ = "0.12.0"

--- a/claude_statusline/cli.py
+++ b/claude_statusline/cli.py
@@ -32,8 +32,10 @@ from .sessions import (
     _CLAUDE_DIR, _CLAUDE_DIR_REAL, _VALID_EFFORT_LEVELS,
     _canonical_effort, _count_activity_with_status,
     _read_cache, _write_cache,
-    get_budget_config, get_clickable_links_enabled, get_compaction_threshold,
+    get_budget_config, get_budget_scope, get_clickable_links_enabled,
+    get_compaction_threshold,
     get_disabled_sections, get_effort_level, get_last_assistant_timestamp_ms,
+    record_and_get_daily_spend,
     get_session_activity_count,
     get_session_tool_count, get_today_session_count,
 )
@@ -972,10 +974,50 @@ def _render_sections_named(n, order, theme):
                 )
 
         elif section == "budget":
-            if cost is not None:
-                budget = get_budget_config()
-                if budget is not None and budget > 0:
-                    pct_used = (cost / budget) * 100
+            # v0.12.0: the numerator is TODAY'S spend across all
+            # sessions on this machine (per-session ledger files under
+            # the user cache dir), matching the config key's own name
+            # (daily_budget_usd) and the README's long-standing "daily
+            # budget tracker" promise. Pre-v0.12.0 this compared the
+            # SESSION cost against the DAILY budget — five $3 sessions
+            # against a $10/day budget each showed a green 30% while
+            # the day was 150% over.
+            #
+            # The "day:" label prefix is deliberate and load-bearing:
+            # it announces the semantic change at upgrade, and it
+            # permanently disambiguates this chip from the adjacent
+            # per-session `cost` chip (two unexplained disagreeing
+            # dollar figures would read as a bug).
+            #
+            # There is NO fallback mode. The total is always the ledger
+            # sum (the writer runs first, so the live session is always
+            # included when it has a cost); an empty or unreachable
+            # ledger degrades to the live session's cost rendered as an
+            # HONEST partial day total under the same label — the
+            # meaning never switches, only completeness degrades.
+            # Escape hatch: budget_scope "session" restores the old
+            # per-session chip (no prefix) for users who calibrated
+            # daily_budget_usd as a per-session ceiling.
+            budget = get_budget_config()
+            if budget is not None and budget > 0:
+                if get_budget_scope() == "session":
+                    shown = cost  # None -> hidden below
+                    prefix = ""
+                else:
+                    session_id = n.get("session_id", "")
+                    # record_and_get_daily_spend ALWAYS folds the live
+                    # session's contribution in (in memory when the sid
+                    # is unusable or the write fails), so found=True
+                    # covers every case where there is any daily signal
+                    # — no separate lower-bound branch needed here, and
+                    # none is wanted: a cli-side "show raw cost" backup
+                    # would over-attribute midnight-spanning sessions.
+                    total, found = record_and_get_daily_spend(
+                        session_id, cost, duration)
+                    shown = total if found else None
+                    prefix = "day:"
+                if shown is not None:
+                    pct_used = (shown / budget) * 100
                     if pct_used >= 90:
                         bc = BRIGHT_RED
                     elif pct_used >= 70:
@@ -987,7 +1029,7 @@ def _render_sections_named(n, order, theme):
                         budget_str = "${}".format(int(budget))
                     else:
                         budget_str = fmt_cost(budget)
-                    label = "{}/{}".format(fmt_cost(cost), budget_str)
+                    label = "{}{}/{}".format(prefix, fmt_cost(shown), budget_str)
                     sections.append(colorize(label, bc, BOLD))
 
         elif section == "version":
@@ -2012,12 +2054,21 @@ def cmd_demo():
     """Show demo output for all themes."""
     data = _demo_data()
 
-    # Mock session functions so demo shows tools/sessions sections
+    # Mock session functions so demo shows tools/sessions sections.
+    # The daily-spend recorder MUST be stubbed too: a demo render on a
+    # machine with a real budget config would otherwise write the fake
+    # "demo-session" $0.73 into the user's REAL spend ledger and
+    # inflate their live day: chip until midnight (monotonic max —
+    # cannot self-correct). The stub echoes the demo cost back as the
+    # day total so the budget chip still demos meaningfully.
     import claude_statusline.cli as _self
     _orig_tool_count = _self.get_session_tool_count
     _orig_session_count = _self.get_today_session_count
+    _orig_record_spend = _self.record_and_get_daily_spend
     _self.get_session_tool_count = lambda sid: 42
     _self.get_today_session_count = lambda: 3
+    _self.record_and_get_daily_spend = (
+        lambda sid, c, d: (c, True) if c is not None else (0.0, False))
 
     try:
         print("claude-status v{} — theme demos\n".format(__version__))
@@ -2048,6 +2099,10 @@ def cmd_demo():
             pass
         try:
             _self.get_today_session_count = _orig_session_count
+        except Exception:
+            pass
+        try:
+            _self.record_and_get_daily_spend = _orig_record_spend
         except Exception:
             pass
 
@@ -2404,8 +2459,15 @@ def cmd_setup():
     import claude_statusline.cli as _self
     _orig_tool_count = _self.get_session_tool_count
     _orig_session_count = _self.get_today_session_count
+    # Stub the spend recorder for the same reason as cmd_demo: the
+    # setup wizard runs on exactly the machine where the user just
+    # configured a real budget, and an unstubbed preview render would
+    # write the fake demo cost into their REAL daily ledger.
+    _orig_record_spend = _self.record_and_get_daily_spend
     _self.get_session_tool_count = lambda sid: 42
     _self.get_today_session_count = lambda: 3
+    _self.record_and_get_daily_spend = (
+        lambda sid, c, d: (c, True) if c is not None else (0.0, False))
 
     try:
         print("\n  Preview:")
@@ -2418,6 +2480,10 @@ def cmd_setup():
             pass
         try:
             _self.get_today_session_count = _orig_session_count
+        except Exception:
+            pass
+        try:
+            _self.record_and_get_daily_spend = _orig_record_spend
         except Exception:
             pass
 

--- a/claude_statusline/sessions.py
+++ b/claude_statusline/sessions.py
@@ -7,6 +7,7 @@ Uses file-based caching to avoid expensive filesystem scans on every render.
 import datetime
 import hashlib
 import json
+import math
 import os
 import re
 import tempfile
@@ -67,13 +68,34 @@ _SESSION_ID_RE = re.compile(r"^[a-zA-Z0-9_-]+$")
 
 
 def _cache_dir():
-    """Return a user-scoped cache directory to avoid multi-user collisions."""
+    """Return a user-scoped cache directory to avoid multi-user collisions.
+
+    Created (and repaired) with mode 0o700: the directory name is
+    predictable from a username (md5 of the home path), and
+    ``exist_ok=True`` would silently adopt a directory pre-created by
+    another local user (classic /tmp squat). That mattered less when
+    the dir held only tool counts; since v0.12.0 it also holds
+    per-session daily spend records, so both reads (privacy) and
+    writes (a squatter planting ledger files to control what the
+    budget chip says) are worth hardening. BEST-EFFORT: if the dir is
+    already owned by another user, the chmod fails silently and this
+    protects nothing — the ledger's shared-tempdir guard in
+    record_and_get_daily_spend is the second line of defense for the
+    fallback path. chmod is a no-op-equivalent on Windows, where the
+    temp dir is already per-user.
+    """
     user_hash = hashlib.md5(
         os.path.expanduser("~").encode("utf-8", "replace")
     ).hexdigest()[:8]
     path = os.path.join(tempfile.gettempdir(), "claude_sl_{}".format(user_hash))
     try:
-        os.makedirs(path, exist_ok=True)
+        os.makedirs(path, mode=0o700, exist_ok=True)
+        # makedirs mode is ignored when the dir already exists (and is
+        # masked by umask on create) — enforce explicitly, best-effort.
+        try:
+            os.chmod(path, 0o700)
+        except OSError:
+            pass
     except OSError:
         return tempfile.gettempdir()
     return path
@@ -705,6 +727,7 @@ def _read_status_config():
         "threshold": None,
         "disabled": [],
         "clickable_links": False,
+        "budget_scope": "daily",
     }
     path = os.path.join(_CLAUDE_DIR, "claude-status-budget.json")
     try:
@@ -713,6 +736,14 @@ def _read_status_config():
         budget = data.get("daily_budget_usd")
         if budget is not None:
             result["budget"] = float(budget)
+        # Escape hatch for users who calibrated daily_budget_usd as a
+        # per-SESSION ceiling under the pre-v0.12.0 behavior: scope
+        # "session" restores the old chip (session cost vs budget, no
+        # "day:" prefix). Anything other than the literal "session"
+        # falls through to the daily default — the documented
+        # semantics of the config key's own name.
+        if data.get("budget_scope") == "session":
+            result["budget_scope"] = "session"
         threshold = data.get("compaction_threshold_pct")
         if threshold is not None:
             threshold = float(threshold)
@@ -744,6 +775,234 @@ def get_budget_config():
     config = _read_status_config()
     val = config.get("budget")
     return float(val) if val is not None else None
+
+
+def get_budget_scope():
+    """Return "daily" (default) or "session" from budget_scope config.
+
+    .get with a default (not [] indexing) because the 30s shared config
+    cache may hold a dict written by an older claude-status version
+    that predates the key — upgrades must not KeyError for up to 30s.
+    """
+    scope = _read_status_config().get("budget_scope", "daily")
+    return scope if scope == "session" else "daily"
+
+
+def _ledger_path(day, session_id):
+    """Cache-dir path for one session's daily spend ledger file.
+
+    The session_id is hashed (same convention as the activity cache) so
+    raw IDs never become filenames.
+    """
+    sid12 = hashlib.md5(
+        session_id.encode("utf-8", errors="replace")).hexdigest()[:12]
+    return os.path.join(_cache_dir(), "spend_{}_{}.json".format(day, sid12))
+
+
+def _read_ledger(path):
+    """Raw ledger read: parsed dict or None. NO freshness check.
+
+    Deliberately NOT _read_cache: ledger files are records, not
+    caches — _read_cache's TTL would report "no file" after any pause
+    longer than 30s, the writer would then re-capture the attribution
+    base at the current cumulative, and the day total would sawtooth
+    toward zero after every think-break. (Adversarial design review
+    caught this before it shipped; do not "simplify" this back.)
+    """
+    try:
+        with open(path, "r") as f:
+            entry = json.load(f)
+        return entry if isinstance(entry, dict) else None
+    except (OSError, IOError, json.JSONDecodeError, ValueError):
+        return None
+
+
+def record_and_get_daily_spend(session_id, cost, duration_ms, _now=None):
+    """Update this session's daily-spend ledger, return today's total.
+
+    Powers the `budget` section's daily semantics (v0.12.0). One call
+    does writer-then-reader in a single pass so the reader always sees
+    the just-written own-session entry — there is no cross-step
+    ordering problem to work around (both run in this process).
+
+    Ledger model: one file per (local day, session), storing the
+    session's cumulative cost ("cost", monotonic via max) and an
+    attribution base ("base"). The session's contribution to the day
+    is max(0, cost - base):
+
+      - Session STARTED TODAY (start ≈ now - duration_ms falls on
+        today's local date): base = 0 — its whole cumulative belongs
+        to today. This also makes upgrade day honest: a mid-session
+        upgrade shows the session's real spend, not $0.
+      - Session started BEFORE today (spans midnight): base = the
+        cumulative at first sight today, so only growth counts.
+      - Duration missing/garbage: base = cumulative at first sight
+        (conservative: undercounts one turn, never overcounts).
+
+    Known, documented limitations (adversarial review, accepted):
+      - A temp-dir wipe mid-day permanently drops that day's PRIOR
+        spend from the total (the base re-captures); undercount only.
+      - A resumed session whose upstream counter jumps to a HIGHER
+        historical baseline mid-day (same session_id) over-attributes
+        the jump to today. Not detectable from stdin; "never
+        overcounts" holds only absent such a baseline change. The
+        same class covers a --resume of a PRIOR-day conversation
+        where upstream carries the old cumulative cost but resets
+        total_duration_ms: it classifies as started-today and the
+        prior days' spend lands on today.
+      - Two live processes sharing one session_id can transiently
+        regress each other's "cost" via max() races; self-heals on
+        the next write. Totals are per-machine.
+      - A backwards local-date change mis-files spend across days.
+        Within any one day's total it never double-counts, but the
+        same increment can appear in the rolled-back day AND remain in
+        the already-written later-day file once the clock returns —
+        wrong-day placement, bounded by the clock excursion.
+
+    Args:
+        session_id: Raw session id from stdin (""/non-string -> writer
+            skips the file; the live contribution is still computed
+            in memory. Any non-empty string is accepted — _ledger_path
+            hashes it, so no filename validation is needed).
+        cost: Session cumulative cost in USD (already _safe_num'd by
+            _normalize on the cli call path; clamped to >= 0 here).
+        duration_ms: Session duration in ms (already _safe_num'd), used
+            only to decide whether the session started today.
+        _now: Test seam for the current epoch seconds; None = real time.
+
+    Returns:
+        Tuple (total, found_any). total is today's summed spend across
+        this machine's sessions, ALWAYS including the live session's
+        contribution when a cost exists (from its ledger file, or in
+        memory when the sid is unusable, the write failed, or the
+        ledger was skipped for the shared-tempdir fallback). found_any
+        False means no daily signal at all (no ledger entries AND no
+        live cost) — the caller hides the chip.
+    """
+    now = time.time() if _now is None else _now
+    t = time.localtime(now)
+    today = "{:04d}-{:02d}-{:02d}".format(t.tm_year, t.tm_mon, t.tm_mday)
+
+    # Fallback guard: when _cache_dir() degrades to the SHARED temp
+    # root (its makedirs-failed fallback), skip ledger file IO
+    # entirely — writing would put spend records world-readable in
+    # /tmp, and READING would sum spend_* files plantable by any
+    # local user directly into the displayed total. The own-session
+    # in-memory contribution below still works, so the chip degrades
+    # to an honest partial total instead of a poisonable one.
+    cache = _cache_dir()
+    ledger_usable = cache != tempfile.gettempdir()
+
+    def _started_today():
+        # try/except because _safe_num guarantees FINITE, not
+        # time-range-sane: a garbage duration like 9e18 ms puts the
+        # computed epoch outside time_t and localtime raises
+        # OverflowError (or OSError on Windows for pre-1970 values) —
+        # which would escape into render() and blank the whole
+        # statusline. Unclassifiable -> False -> conservative
+        # base = cur (undercount, never crash).
+        if duration_ms is not None and duration_ms >= 0:
+            try:
+                s = time.localtime(now - duration_ms / 1000.0)
+            except (OverflowError, OSError, ValueError):
+                return False
+            return (s.tm_year, s.tm_mon, s.tm_mday) == \
+                   (t.tm_year, t.tm_mon, t.tm_mday)
+        return False
+
+    # --- writer (own session) -----------------------------------------
+    # own_contrib is ALWAYS computed in memory when a cost exists —
+    # even when the sid is unusable or the write fails — so the reader
+    # can guarantee the live session is never silently missing from a
+    # chip labeled "day:". (Silent-failure review: a failed write with
+    # other sessions' files present used to render a day total that
+    # EXCLUDED the live session — day:$2 beside a $99 cost chip.)
+    own_contrib = None
+    own_name = None
+    if cost is not None:
+        cur = max(0.0, float(cost))
+        if ledger_usable and session_id and isinstance(session_id, str):
+            path = _ledger_path(today, session_id)
+            own_name = os.path.basename(path)
+            entry = _read_ledger(path)
+            base = _safe_entry_num(entry, "base") if entry else None
+            prev = _safe_entry_num(entry, "cost") if entry else None
+            if prev is None or base is None:
+                # First sight today (or corrupt entry — recapture
+                # rather than trust garbage). Base per the start-day
+                # rule above.
+                base = 0.0 if _started_today() else cur
+                prev = cur
+                _write_ledger(path, {"cost": cur, "base": base})
+            elif cur > prev:
+                prev = cur
+                _write_ledger(path, {"cost": cur, "base": base})
+            own_contrib = max(0.0, max(prev, cur) - base)
+        else:
+            # No usable sid / ledger unusable: in-memory only, same
+            # attribution rule. Nothing on disk to double-count.
+            base = 0.0 if _started_today() else cur
+            own_contrib = max(0.0, cur - base)
+
+    # --- reader (all sessions, today) ----------------------------------
+    total = 0.0
+    found = False
+    own_seen = False
+    prefix = "spend_{}_".format(today)
+    if ledger_usable:
+        try:
+            for fentry in os.scandir(cache):
+                name = fentry.name
+                if not (name.startswith(prefix) and name.endswith(".json")):
+                    continue
+                entry = _read_ledger(fentry.path)
+                if entry is None:
+                    continue
+                c = _safe_entry_num(entry, "cost")
+                if c is None:
+                    continue
+                b = _safe_entry_num(entry, "base")
+                contrib = max(0.0, c - (b if b is not None else 0.0))
+                if name == own_name:
+                    # Substitution in CONTRIBUTION units (not cumulative
+                    # — the round-1 design-review units-mismatch), for
+                    # the race where our write landed then a sibling
+                    # process regressed the file between write and scan.
+                    contrib = max(contrib, own_contrib or 0.0)
+                    own_seen = True
+                total += contrib
+                found = True
+        except OSError:
+            pass
+    if own_contrib is not None and not own_seen:
+        # Own write failed, sid unusable, or ledger skipped — the live
+        # session still counts, in memory.
+        total += own_contrib
+        found = True
+    return total, found
+
+
+def _safe_entry_num(entry, key):
+    """Finite float from a ledger dict key, else None (garbage-proof)."""
+    try:
+        num = float(entry.get(key))
+    except (TypeError, ValueError):
+        return None
+    return num if math.isfinite(num) else None
+
+
+def _write_ledger(path, value):
+    """Atomic ledger write (tmp + os.replace), best-effort."""
+    tmp = path + ".tmp"
+    try:
+        with open(tmp, "w") as f:
+            json.dump(value, f)
+        os.replace(tmp, path)
+    except (OSError, IOError):
+        try:
+            os.unlink(tmp)
+        except OSError:
+            pass
 
 
 def get_compaction_threshold():

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "claude-status"
-version = "0.11.0"
+version = "0.12.0"
 description = "Beautiful, informative status line for Claude Code — zero dependencies, cross-platform"
 readme = "README.md"
 license = {text = "MIT"}

--- a/tests/test_all.py
+++ b/tests/test_all.py
@@ -69,6 +69,8 @@ _REAL_SETTINGS_PATH = os.path.join(
 _real_settings_hash_before = None
 _settings_redirect_dir = None
 _prev_settings_env = None
+_cache_redirect_dir = None
+_prev_cache_dir_fn = None
 
 # Distinct, never-None sentinel for "the real settings file exists but we
 # could NOT read it" (permission denied, transient lock, etc.). This MUST
@@ -101,13 +103,26 @@ def _hash_real_settings():
 
 def setUpModule():
     global _real_settings_hash_before, _settings_redirect_dir
-    global _prev_settings_env
+    global _prev_settings_env, _cache_redirect_dir, _prev_cache_dir_fn
     _real_settings_hash_before = _hash_real_settings()
     # Redirect every unpatched settings read/write to a throwaway file.
     _settings_redirect_dir = tempfile.mkdtemp(prefix="claude-status-test-")
     _prev_settings_env = os.environ.get("CLAUDE_STATUSLINE_SETTINGS_PATH")
     os.environ["CLAUDE_STATUSLINE_SETTINGS_PATH"] = os.path.join(
         _settings_redirect_dir, "settings.json")
+    # Redirect every unpatched CACHE read/write to a throwaway dir —
+    # the v0.12.0 daily-spend ledger made this load-bearing: any render
+    # test that passes session_id + cost triggers the budget path on a
+    # machine with a real ~/.claude/claude-status-budget.json, and an
+    # unredirected run would write phantom spend_* ledger files into
+    # the REAL cache dir, inflating the maintainer's live day-spend
+    # chip with test dollars until midnight (monotonic max — it cannot
+    # self-correct). Same incident class as #96; same chokepoint fix.
+    # Per-class setUp patches layer on top of this harmlessly.
+    from claude_statusline import sessions as _sessions_mod
+    _cache_redirect_dir = tempfile.mkdtemp(prefix="claude-status-cache-")
+    _prev_cache_dir_fn = _sessions_mod._cache_dir
+    _sessions_mod._cache_dir = lambda: _cache_redirect_dir
 
 
 def tearDownModule():
@@ -128,6 +143,14 @@ def tearDownModule():
     if _settings_redirect_dir:
         import shutil as _shutil
         _shutil.rmtree(_settings_redirect_dir, ignore_errors=True)
+    # Restore the cache-dir redirect and clean its temp dir (before the
+    # assert below for the same leak-on-raise reason).
+    if _prev_cache_dir_fn is not None:
+        from claude_statusline import sessions as _sessions_mod
+        _sessions_mod._cache_dir = _prev_cache_dir_fn
+    if _cache_redirect_dir:
+        import shutil as _shutil2
+        _shutil2.rmtree(_cache_redirect_dir, ignore_errors=True)
     if after != _real_settings_hash_before:
         raise AssertionError(
             "A test mutated the real ~/.claude/settings.json! Some test "
@@ -687,6 +710,441 @@ class TestCostRateSection(unittest.TestCase):
         finally:
             THEMES["default"]["line2"] = orig_line2
             cli_mod.get_branch = orig_branch
+
+
+class TestDailySpendLedger(unittest.TestCase):
+    """Per-(day, session) spend ledger powering the budget section's
+    daily semantics (v0.12.0). Every scenario here traces to a finding
+    from the adversarial design review — see the docstring of
+    record_and_get_daily_spend for the model."""
+
+    def setUp(self):
+        import shutil as shutil_mod
+        from claude_statusline import sessions as sessions_mod
+        self._shutil = shutil_mod
+        self._sess = sessions_mod
+        self._tmp = tempfile.mkdtemp(prefix="claude-status-ledger-")
+        self._orig_cache_dir = sessions_mod._cache_dir
+        sessions_mod._cache_dir = lambda: self._tmp
+        # Determinism: pin "now" to local NOON of the current day.
+        # With real time.time(), a suite run in the minutes after
+        # local midnight would misclassify "started today" (start ≈
+        # now - duration lands on yesterday) and hard-fail several
+        # attribution tests — the project's determinism rule forbids
+        # that. Noon keeps every duration in these tests (< 12h) on
+        # today's side of the boundary.
+        lt = time.localtime()
+        self._noon = time.mktime(
+            (lt.tm_year, lt.tm_mon, lt.tm_mday, 12, 0, 0, 0, 0, -1))
+        self._day = time.strftime("%Y-%m-%d", time.localtime(self._noon))
+
+    def tearDown(self):
+        self._sess._cache_dir = self._orig_cache_dir
+        self._shutil.rmtree(self._tmp, ignore_errors=True)
+
+    def _rec(self, sid, cost, dur_ms, now=None):
+        return self._sess.record_and_get_daily_spend(
+            sid, cost, dur_ms, _now=self._noon if now is None else now)
+
+    # --- attribution rules --------------------------------------------
+
+    def test_started_today_full_attribution(self):
+        """Session started today: base=0, whole cumulative counts.
+        This is also the upgrade-day honesty case."""
+        total, found = self._rec("sid-a", 3.0, 600_000)
+        self.assertTrue(found)
+        self.assertAlmostEqual(total, 3.0)
+
+    def test_midnight_spanning_growth_only(self):
+        """Session started 30h ago: base captured at first sight, only
+        today's growth counts — the over-attribution the base rule
+        exists to prevent."""
+        total, _ = self._rec("sid-b", 8.0, 30 * 3600 * 1000)
+        self.assertAlmostEqual(total, 0.0)
+        total, _ = self._rec("sid-b", 8.6, 30 * 3600 * 1000 + 60_000)
+        self.assertAlmostEqual(total, 0.6)
+
+    def test_missing_duration_conservative(self):
+        """No duration signal -> base=cur (undercount one turn, never
+        overcount)."""
+        total, _ = self._rec("sid-c", 1.5, None)
+        self.assertAlmostEqual(total, 0.0)
+        total, _ = self._rec("sid-c", 2.0, None)
+        self.assertAlmostEqual(total, 0.5)
+
+    def test_monotonic_no_regression_on_stale_rerender(self):
+        self._rec("sid-d", 3.0, 600_000)
+        total, _ = self._rec("sid-d", 2.9, 610_000)  # stale/lower
+        self.assertAlmostEqual(total, 3.0)
+
+    def test_multi_session_sum(self):
+        self._rec("sid-e", 3.0, 600_000)
+        total, _ = self._rec("sid-f", 2.5, 300_000)
+        self.assertAlmostEqual(total, 5.5)
+
+    def test_negative_cost_clamped(self):
+        """Garbage negative cur must not create phantom spend when a
+        later legit value arrives (review finding: base=-3 then cur=2
+        would contribute 5). Exact value pinned: the clamp writes
+        {cost:0, base:0}, then cost 2 contributes exactly 2.0 — a
+        range assertion would also pass an over-clamp that silently
+        dropped the legitimate spend."""
+        self._rec("sid-g", -3.0, 60_000)
+        total, _ = self._rec("sid-g", 2.0, 120_000)
+        self.assertAlmostEqual(total, 2.0)
+
+    # --- robustness ----------------------------------------------------
+
+    def test_corrupt_and_garbage_files_skipped(self):
+        self._rec("sid-h", 4.0, 600_000)
+        day = self._day  # same pinned clock as the recording calls
+        for name, content in (
+            ("spend_{}_aaaaaaaaaaaa.json".format(day), "{not json"),
+            ("spend_{}_bbbbbbbbbbbb.json".format(day), "[1,2]"),
+            ("spend_{}_cccccccccccc.json".format(day),
+             json.dumps({"cost": "abc", "base": 0})),
+            ("spend_{}_dddddddddddd.json".format(day),
+             json.dumps({"cost": float("nan"), "base": 0})),
+        ):
+            with open(os.path.join(self._tmp, name), "w") as f:
+                f.write(content)
+        total, _ = self._rec("sid-h", 4.0, 600_000)
+        self.assertAlmostEqual(total, 4.0)
+
+    def test_yesterday_files_not_summed(self):
+        """Day boundary via the _now seam: an entry recorded 'two days
+        ago' must not appear in today's total."""
+        self._rec("sid-i", 9.0, 60_000, now=self._noon - 2 * 86400)
+        total, found = self._rec("sid-j", 1.0, 60_000)
+        self.assertAlmostEqual(total, 1.0)
+        self.assertTrue(found)
+
+    def test_shared_sid_interleave_self_heals(self):
+        """Two processes sharing one session_id (double resume) can
+        transiently regress each other via max(); the file must never
+        go NEGATIVE in contribution and must self-heal once the higher
+        counter writes again."""
+        self._rec("sid-k", 5.0, 600_000)   # process A
+        self._rec("sid-k", 6.0, 650_000)   # process B, higher
+        total, _ = self._rec("sid-k", 5.5, 700_000)  # A again, lower
+        self.assertGreaterEqual(total, 0.0)
+        total, _ = self._rec("sid-k", 6.2, 750_000)  # B recovers
+        self.assertAlmostEqual(total, 6.2)
+
+    def test_no_session_id_live_contribution_still_counts(self):
+        """Silent-failure review: a chip labeled day: must NEVER
+        exclude the live session. With no usable sid the contribution
+        is computed in memory — 2.0 (other) + 99.0 (live, started
+        today) = 101.0, NOT 2.0."""
+        self._rec("sid-l", 2.0, 60_000)
+        total, found = self._rec("", 99.0, 60_000)
+        self.assertTrue(found)
+        self.assertAlmostEqual(total, 101.0)
+
+    def test_no_sid_midnight_spanning_growth_only_in_memory(self):
+        """The in-memory path applies the SAME attribution rule: a
+        midnight-spanning session (started 30h ago) with no usable sid
+        contributes 0, not its full cumulative — a cli-side raw-cost
+        fallback would have over-attributed here."""
+        self._rec("sid-m", 2.0, 60_000)
+        total, found = self._rec("", 50.0, 30 * 3600 * 1000)
+        self.assertTrue(found)
+        self.assertAlmostEqual(total, 2.0)
+
+    def test_empty_ledger_not_found(self):
+        total, found = self._rec("", None, None)
+        self.assertFalse(found)
+        self.assertAlmostEqual(total, 0.0)
+
+    def test_shared_tempdir_fallback_skips_ledger(self):
+        """When _cache_dir degrades to the SHARED temp root, ledger IO
+        must be skipped entirely: no spend file is written (privacy),
+        no foreign spend_* files are summed (poisoning), and the live
+        session still counts in memory."""
+        self._sess._cache_dir = lambda: tempfile.gettempdir()
+        # A poisoned file in the shared root must NOT be readable into
+        # the total. Plant one with a unique sid hash, then verify.
+        poison = os.path.join(
+            tempfile.gettempdir(),
+            "spend_{}_feedfacefeed.json".format(self._day))
+        with open(poison, "w") as f:
+            f.write(json.dumps({"cost": 500.0, "base": 0.0}))
+        try:
+            total, found = self._rec("sid-n", 3.0, 60_000)
+            self.assertTrue(found)
+            self.assertAlmostEqual(total, 3.0)  # own only; poison ignored
+            # And nothing was written for our sid into the shared root.
+            import hashlib as _h
+            sid12 = _h.md5(b"sid-n").hexdigest()[:12]
+            own = os.path.join(
+                tempfile.gettempdir(),
+                "spend_{}_{}.json".format(self._day, sid12))
+            self.assertFalse(os.path.exists(own),
+                             "ledger must not write into the shared temp root")
+        finally:
+            os.unlink(poison)
+
+    def test_unreachable_cache_dir_degrades(self):
+        """Nonexistent cache dir: writes swallowed, scan OSError caught,
+        live contribution still returned in memory."""
+        self._sess._cache_dir = lambda: os.path.join(
+            self._tmp, "does", "not", "exist")
+        total, found = self._rec("sid-o", 2.5, 60_000)
+        self.assertTrue(found)
+        self.assertAlmostEqual(total, 2.5)
+
+    def test_tmp_leftover_ignored(self):
+        """A crash-orphaned .json.tmp must be excluded by the reader's
+        endswith('.json') filter — pin, not a bug."""
+        self._rec("sid-p", 1.0, 60_000)
+        leftover = os.path.join(
+            self._tmp, "spend_{}_aaaabbbbcccc.json.tmp".format(self._day))
+        with open(leftover, "w") as f:
+            f.write(json.dumps({"cost": 900.0, "base": 0.0}))
+        total, _ = self._rec("sid-p", 1.0, 60_000)
+        self.assertAlmostEqual(total, 1.0)
+
+    def test_cost_none_sid_present_reader_only(self):
+        """cost=None with a sid: writer skips, no in-memory contribution,
+        but other sessions' entries still sum."""
+        self._rec("sid-q", 4.0, 60_000)
+        total, found = self._sess.record_and_get_daily_spend(
+            "sid-r", None, None, _now=self._noon)
+        self.assertTrue(found)
+        self.assertAlmostEqual(total, 4.0)
+
+
+class TestBudgetSectionDaily(unittest.TestCase):
+    """End-to-end budget chip with daily semantics: day: label,
+    summed numerator, color bands on the TOTAL, scope escape hatch,
+    and the honest lower-bound degrade."""
+
+    def _plain(self, s):
+        return re.sub(r"\x1b\[[0-9;]*m", "", s)
+
+    def setUp(self):
+        import shutil as shutil_mod
+        import claude_statusline.cli as cli_mod
+        from claude_statusline import sessions as sessions_mod
+        self._shutil = shutil_mod
+        self._cli = cli_mod
+        self._sess = sessions_mod
+        self._tmp = tempfile.mkdtemp(prefix="claude-status-budget-")
+        self._orig_cache_dir = sessions_mod._cache_dir
+        sessions_mod._cache_dir = lambda: self._tmp
+        self._orig_budget = cli_mod.get_budget_config
+        self._orig_scope = cli_mod.get_budget_scope
+        self._orig_branch = cli_mod.get_branch
+        cli_mod.get_budget_config = lambda: 10.0
+        cli_mod.get_budget_scope = lambda: "daily"
+        cli_mod.get_branch = lambda: "main"
+        self._orig_line1 = THEMES["default"]["line1"]
+        THEMES["default"]["line1"] = ["budget"]
+        # Determinism: pin the ledger clock to local noon (see
+        # TestDailySpendLedger.setUp for why — midnight would flip the
+        # started-today classification). cli.render has no _now
+        # parameter, so wrap the imported name at the cli module level.
+        lt = time.localtime()
+        self._noon = time.mktime(
+            (lt.tm_year, lt.tm_mon, lt.tm_mday, 12, 0, 0, 0, 0, -1))
+        self._orig_record = cli_mod.record_and_get_daily_spend
+        cli_mod.record_and_get_daily_spend = (
+            lambda sid, c, d: self._sess.record_and_get_daily_spend(
+                sid, c, d, _now=self._noon))
+
+    def _seed(self, sid, cost, dur):
+        self._sess.record_and_get_daily_spend(sid, cost, dur, _now=self._noon)
+
+    def tearDown(self):
+        self._sess._cache_dir = self._orig_cache_dir
+        self._cli.get_budget_config = self._orig_budget
+        self._cli.get_budget_scope = self._orig_scope
+        self._cli.get_branch = self._orig_branch
+        self._cli.record_and_get_daily_spend = self._orig_record
+        THEMES["default"]["line1"] = self._orig_line1
+        self._shutil.rmtree(self._tmp, ignore_errors=True)
+
+    def _render(self, sid, cost, dur):
+        data = {"git_branch": "main", "session_id": sid,
+                "context_window": {"used_percentage": 10}}
+        if cost is not None:
+            data["cost"] = {"total_cost_usd": cost,
+                            "total_duration_ms": dur}
+        return self._plain(self._cli.render(data, "default"))
+
+    def test_day_label_and_sum(self):
+        self._sess.record_and_get_daily_spend("other-sess", 4.0, 600_000)
+        out = self._render("this-sess", 3.4, 700_000)
+        self.assertIn("day:$7.4/$10", out)
+
+    def test_color_band_on_total_not_session(self):
+        """$4 (other) + $5.2 (this) = $9.2 of $10 -> >=90% band. The
+        pre-v0.12.0 bug would have used $5.2 (52%, green)."""
+        self._sess.record_and_get_daily_spend("other-sess", 4.0, 600_000)
+        raw = self._cli.render({
+            "git_branch": "main", "session_id": "this-sess",
+            "cost": {"total_cost_usd": 5.2, "total_duration_ms": 700_000},
+            "context_window": {"used_percentage": 10}}, "default")
+        self.assertIn("day:$9.2/$10", self._plain(raw))
+        self.assertIn(BRIGHT_RED, raw)
+
+    def test_upgrade_day_lower_bound(self):
+        """Empty ledger + live session (started today) -> live cost as
+        the honest partial day total, same day: label."""
+        out = self._render("fresh-sess", 2.1, 400_000)
+        self.assertIn("day:$2.1/$10", out)
+
+    def test_no_session_id_still_day_label(self):
+        """Writer can't record without a sid; the live cost is still a
+        true lower bound and keeps the day: label (meaning never
+        switches — design review required this)."""
+        out = self._render("", 2.1, 400_000)
+        self.assertIn("day:$2.1/$10", out)
+
+    def test_scope_session_restores_old_chip(self):
+        self._cli.get_budget_scope = lambda: "session"
+        self._sess.record_and_get_daily_spend("other-sess", 4.0, 600_000)
+        out = self._render("this-sess", 3.4, 700_000)
+        self.assertIn("$3.4/$10", out)
+        self.assertNotIn("day:", out)
+
+    def test_hidden_without_budget(self):
+        self._cli.get_budget_config = lambda: None
+        out = self._render("this-sess", 3.4, 700_000)
+        self.assertNotIn("/$", out)
+
+    def test_hidden_no_cost_no_ledger(self):
+        out = self._render("this-sess", None, None)
+        self.assertNotIn("day:", out)
+
+    def test_no_cost_but_others_spent_shows_day_total(self):
+        """Live session has no cost yet, but other sessions spent today
+        — the chip still shows the day total (the cli comment promises
+        this; previously untested)."""
+        self._seed("other-sess", 4.0, 600_000)
+        out = self._render("this-sess", None, None)
+        self.assertIn("day:$4.0/$10", out)
+
+    def test_garbage_duration_never_crashes_render(self):
+        """time.localtime raises OverflowError/OSError for epoch values
+        outside time_t range — a garbage duration like 9e18 ms must
+        degrade to the conservative base, not blank the statusline.
+        (Code-review finding, reproduced before fixing.)"""
+        for bad_dur in (9e18, 1.8e15):
+            out = self._render("weird-sess-{}".format(bad_dur), 2.0, bad_dur)
+            self.assertIn("main", out)  # render survived
+            # Conservative base=cur -> contribution 0 -> chip shows $0
+            # or is present; the essential assertion is no crash.
+
+
+class TestBudgetScopeConfig(unittest.TestCase):
+    """get_budget_scope(): 'daily' default, 'session' honored, garbage
+    and stale cached dicts (pre-v0.12.0, key absent) fall to daily."""
+
+    def test_default_daily(self):
+        from claude_statusline import sessions as sess
+        orig = sess._read_status_config
+        sess._read_status_config = lambda: {"budget": 10.0}
+        try:
+            self.assertEqual(sess.get_budget_scope(), "daily")
+        finally:
+            sess._read_status_config = orig
+
+    def test_session_honored(self):
+        from claude_statusline import sessions as sess
+        orig = sess._read_status_config
+        sess._read_status_config = lambda: {"budget_scope": "session"}
+        try:
+            self.assertEqual(sess.get_budget_scope(), "session")
+        finally:
+            sess._read_status_config = orig
+
+    def test_garbage_falls_to_daily(self):
+        from claude_statusline import sessions as sess
+        orig = sess._read_status_config
+        for bad in ("weekly", 42, None, ["session"]):
+            sess._read_status_config = lambda b=bad: {"budget_scope": b}
+            try:
+                self.assertEqual(sess.get_budget_scope(), "daily")
+            finally:
+                sess._read_status_config = orig
+
+    def test_scope_parsed_from_real_config_file(self):
+        """End-to-end through the ACTUAL file parse in
+        _read_status_config — the unit stubs above never execute the
+        `data.get("budget_scope") == "session"` branch, so a typo
+        there would ship green without this test."""
+        import shutil as shutil_mod
+        from claude_statusline import sessions as sess
+        tmp_claude = tempfile.mkdtemp(prefix="claude-status-scope-")
+        orig_dir = sess._CLAUDE_DIR
+        sess._CLAUDE_DIR = tmp_claude
+        try:
+            with open(os.path.join(tmp_claude, "claude-status-budget.json"),
+                      "w", encoding="utf-8") as f:
+                json.dump({"daily_budget_usd": 10,
+                           "budget_scope": "session"}, f)
+            # Bust the 30s shared config cache so the file is re-read.
+            try:
+                os.remove(sess._cache_path("status_config"))
+            except OSError:
+                pass
+            self.assertEqual(sess.get_budget_scope(), "session")
+            self.assertEqual(sess.get_budget_config(), 10.0)
+        finally:
+            sess._CLAUDE_DIR = orig_dir
+            try:
+                os.remove(sess._cache_path("status_config"))
+            except OSError:
+                pass
+            shutil_mod.rmtree(tmp_claude, ignore_errors=True)
+
+
+class TestCacheDirPermissions(unittest.TestCase):
+    """0o700 hardening on the user cache dir (v0.12.0) — the dir name
+    is predictable and now holds spend records. POSIX-only: Windows
+    chmod only toggles the read-only bit and %TEMP% is per-user."""
+
+    @unittest.skipUnless(os.name == "posix", "POSIX permission bits")
+    def test_fresh_create_is_0700(self):
+        import stat as stat_mod
+        import shutil as shutil_mod
+        from claude_statusline import sessions as sess
+        tmp_root = tempfile.mkdtemp(prefix="claude-status-perm-")
+        orig_gettempdir = tempfile.gettempdir
+        tempfile.gettempdir = lambda: tmp_root
+        try:
+            d = _prev_cache_dir_fn()  # the REAL _cache_dir
+            self.assertTrue(d.startswith(tmp_root))
+            mode = stat_mod.S_IMODE(os.stat(d).st_mode)
+            self.assertEqual(mode, 0o700)
+        finally:
+            tempfile.gettempdir = orig_gettempdir
+            shutil_mod.rmtree(tmp_root, ignore_errors=True)
+
+    @unittest.skipUnless(os.name == "posix", "POSIX permission bits")
+    def test_existing_dir_repaired_to_0700(self):
+        import stat as stat_mod
+        import shutil as shutil_mod
+        import hashlib as hashlib_mod
+        from claude_statusline import sessions as sess
+        tmp_root = tempfile.mkdtemp(prefix="claude-status-perm-")
+        user_hash = hashlib_mod.md5(
+            os.path.expanduser("~").encode("utf-8", "replace")
+        ).hexdigest()[:8]
+        pre = os.path.join(tmp_root, "claude_sl_{}".format(user_hash))
+        os.makedirs(pre, mode=0o755)
+        os.chmod(pre, 0o755)
+        orig_gettempdir = tempfile.gettempdir
+        tempfile.gettempdir = lambda: tmp_root
+        try:
+            d = _prev_cache_dir_fn()
+            mode = stat_mod.S_IMODE(os.stat(d).st_mode)
+            self.assertEqual(mode, 0o700,
+                             "pre-existing permissive dir must be repaired")
+        finally:
+            tempfile.gettempdir = orig_gettempdir
+            shutil_mod.rmtree(tmp_root, ignore_errors=True)
 
 
 class TestSafeNumFinite(unittest.TestCase):
@@ -1526,13 +1984,22 @@ class TestSessions(unittest.TestCase):
         self.assertEqual(get_session_tool_count("foo\\bar"), 0)
 
     def test_cache_path_is_user_scoped(self):
-        """Cache files should be in a user-specific directory."""
-        from claude_statusline.sessions import _cache_path
-        path = _cache_path("test")
-        # Should contain a hash-based subdirectory, not be flat in /tmp
-        self.assertIn("claude_sl_", path)
-        parent = os.path.basename(os.path.dirname(path))
-        self.assertTrue(parent.startswith("claude_sl_"))
+        """Cache files should be in a user-specific directory. The
+        module-scope redirect (see setUpModule) points _cache_dir at a
+        plain temp dir for isolation, so restore the REAL function just
+        for this assertion — it tests the production path shape."""
+        from claude_statusline import sessions as sessions_mod
+        redirected = sessions_mod._cache_dir
+        assert _prev_cache_dir_fn is not None
+        sessions_mod._cache_dir = _prev_cache_dir_fn
+        try:
+            path = sessions_mod._cache_path("test")
+            # Should contain a hash-based subdirectory, not flat /tmp
+            self.assertIn("claude_sl_", path)
+            parent = os.path.basename(os.path.dirname(path))
+            self.assertTrue(parent.startswith("claude_sl_"))
+        finally:
+            sessions_mod._cache_dir = redirected
 
     def test_get_budget_config_no_file(self):
         from claude_statusline.sessions import get_budget_config
@@ -1665,12 +2132,25 @@ class TestSessions(unittest.TestCase):
 
 class TestBudgetSection(unittest.TestCase):
     def test_budget_warning_red(self):
-        """Budget at 90%+ should show bold red."""
+        """Budget at 90%+ should show bold red — modernized for the
+        v0.12.0 daily semantics: assert the day: chip value AND the
+        actual red color (the original never asserted the color and
+        its $0.95 assertion was satisfied by the adjacent cost chip).
+        The module-scope cache redirect isolates the ledger; no sid is
+        passed, so the in-memory started-today contribution renders."""
         import claude_statusline.cli as cli_mod
+        from claude_statusline import sessions as sessions_mod
         orig = cli_mod.get_budget_config
-
+        orig_record = cli_mod.record_and_get_daily_spend
         cli_mod.get_budget_config = lambda: 1.0
-
+        # Pin the ledger clock to local noon (midnight determinism —
+        # same rationale as TestDailySpendLedger.setUp).
+        lt = time.localtime()
+        noon = time.mktime(
+            (lt.tm_year, lt.tm_mon, lt.tm_mday, 12, 0, 0, 0, 0, -1))
+        cli_mod.record_and_get_daily_spend = (
+            lambda sid, c, d: sessions_mod.record_and_get_daily_spend(
+                sid, c, d, _now=noon))
         try:
             data = {
                 "context_window": {"used_percentage": 30,
@@ -1679,13 +2159,13 @@ class TestBudgetSection(unittest.TestCase):
                 "git_branch": "main",
             }
             result = render(data)
-            # Should contain both current cost and budget formatted
-            self.assertIn("$0.95", result)
+            self.assertIn("day:$0.95/$1", re.sub(r"\x1b\[[0-9;]*m", "", result))
+            self.assertIn(BRIGHT_RED, result)  # 95% >= 90% band
             # Whole-number budgets should display without trailing .0
-            self.assertIn("$1", result)
-            self.assertNotIn("$1.0", result)
+            self.assertNotIn("$1.0", re.sub(r"\x1b\[[0-9;]*m", "", result))
         finally:
             cli_mod.get_budget_config = orig
+            cli_mod.record_and_get_daily_spend = orig_record
 
     def test_budget_not_shown_without_config(self):
         """Without budget config, no budget section should appear."""


### PR DESCRIPTION
## Summary

**Fixes the budget section's semantics** (⚠️ behavior change, prominently flagged in the CHANGELOG): the chip now compares **today's spend — summed across all sessions on this machine — against `daily_budget_usd`**, labeled `day:$7.4/$10`. Previously it compared only the *current session's* cost against the daily budget: five $3 sessions against a $10/day budget each showed a comfortable green `$3.0/$10` while the day was at 150% of budget. The config key's name, the README, and the FAQ were always unanimous that the contract is daily; the display was the wrong half.

- **`day:` label** announces the change at upgrade and permanently disambiguates from the adjacent per-session `cost` chip.
- **Escape hatch:** `"budget_scope": "session"` in the same config restores the old per-session chip (byte-identical output, no prefix).
- **Day-one note** (also in FAQ): totals accumulate from the moment of upgrade; per-machine scope documented bluntly.

## Mechanism (design adversarially reviewed BEFORE code)

One ledger file per (local day, session): cumulative cost (monotonic `max`) + an attribution base so midnight-spanning sessions contribute only post-midnight growth. Started-today derives from `cost.total_duration_ms` — started-today sessions get full attribution, which keeps upgrade day honest. **The live session's contribution is always folded into the total** (in memory when the sid is unusable, the write fails, or the ledger is skipped) — a chip labeled `day:` can never silently exclude the session in front of you, and never silently reverts to per-session semantics.

Two pre-code design reviews killed: a units-mismatched substitution rule (would have re-inflated midnight sessions), a 30s-TTL read that would have sawtoothed the total after every pause, and a contradictory base rule. Four post-code reviews then caught and fixed: a reproduced `time.localtime` crash on garbage durations, a #96-class test-isolation blocker, `--demo`/`--setup` writing phantom spend into the real ledger, a midnight determinism window in the new tests, and several doc inaccuracies.

## Hardening shipped with it

- **Cache dir `0o700`** (predictable name; now holds spend records) — created and repaired best-effort; POSIX permission pins in CI.
- **Shared-tempdir fallback guard** — the ledger refuses to read or write in the world-shared temp root (no world-readable spend files; no third-party-plantable `spend_*` files summed into your chip).
- **Test-suite cache isolation at module scope** — no test can ever write phantom spend into a maintainer's live chip (the #96 incident chokepoint pattern); `--demo` and the setup wizard stub the recorder for the same reason.
- **Garbage-duration crash fixed** — finite-but-absurd durations (`9e18` ms) no longer blank the statusline via `time.localtime` OverflowError (reproduced first).

## Testing

**655 tests (+31)** — attribution rules (started-today / midnight-spanning / missing-duration / in-memory variants), monotonicity, exact-value clamp pins, corrupt/garbage/`.tmp` ledger files, day-boundary + midnight determinism via an injected noon clock, shared-sid interleave self-healing, tempdir poisoning guard, unreachable-dir degrade, crash regression, e2e chip with bands on the *total*, scope escape hatch (unit + real config-file parse), and `0o700` create/repair pins (POSIX-only; skip on Windows, run on Linux/macOS CI legs). Verified on this machine: full suite + `--demo` leave **zero** ledger files in the real cache dir.

Pure stdlib, zero dependencies. Docs: README feature row, FAQ rewrite, prominent CHANGELOG flag.