### PR TITLE
feat: subagentStatusLine support — per-task agent rows (#110, closes #91)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,7 +23,7 @@ The user must restart Claude Code for the status line to appear. Tell them this 
 claude-status --print-config
 ```
 
-A successful install prints 8 `key=value` lines in stable order — values are always present (empty string when absent) so a parser can rely on a fixed line count:
+A successful install prints 9 `key=value` lines in stable order (8 original + `subagent`, appended in v0.13.0 — key=value and first-8-lines parsers keep working; a parser asserting an exact 8-line count needs updating) — values are always present (empty string when absent) so a parser can rely on a fixed line count:
 
 ```
 installed=true
@@ -34,6 +34,13 @@ theme=<theme name; "default" when --theme not specified>
 version=<package version, e.g. 0.5.5>
 settings_path=<absolute path to settings.json>
 settings_state=ok
+subagent=<installed | installed_missing_flag | not_installed>
+```
+
+`subagent` reports the optional `subagentStatusLine` hook (per-task agent rows, v0.13.0+). To enable it on the user's behalf, add to settings.json alongside `statusLine`:
+
+```json
+"subagentStatusLine": {"type": "command", "command": "claude-status --subagent"}
 ```
 
 **Exit codes** (relied on by scripts):

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,31 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.13.0] - 2026-07-09
+
+### Added
+
+- **Per-subagent status rows** ([#110](https://github.com/mkalkere/claude-statusline/issues/110), closes [#91](https://github.com/mkalkere/claude-statusline/issues/91)) — claude-status now serves Claude Code's `subagentStatusLine` hook: each running subagent task renders as `[Explore] [███░░░░░] 41% · 23s · Sonnet 5` (name, per-task context bar + percentage, elapsed time, model) in the agent panel. One binary, both hooks — add alongside your `statusLine` entry:
+
+  ```json
+  "subagentStatusLine": {"type": "command", "command": "claude-status --subagent"}
+  ```
+
+  - **`--subagent` is the documented interface**; a subagent payload arriving on the bare command is auto-detected as a fallback (with a stderr note suggesting the flag). With the flag, every error path prints nothing — a JSONL consumer never sees a stray statusline or the main hook's `?` fallback (a truncated payload that merely *looks* subagent-shaped also suppresses `?`).
+  - **Emitted per the documented upstream contract**: JSONL `{"id", "content"}` per task; ids echo back as their original JSON type; a task that can't be rendered (malformed, finished, or nothing fits the width) is **omitted** — upstream's default row always beats a hidden or garbled one, and empty content (which hides a row) is never emitted.
+  - **Status-aware**: terminal statuses (completed/failed/cancelled/…) hand the row back to Claude Code's default rendering — no forever-ticking elapsed timer on finished tasks. Unknown statuses fail open (render).
+  - **Degrades per segment**: percentage needs `tokenCount` ≥ 0 AND `contextWindowSize` > 0 (displayed pct clamps at 100); elapsed accepts `startTime` as ISO-8601, epoch seconds, or epoch milliseconds (magnitude-banded — the format is undocumented upstream) and drops on clock skew or >7-day ages; the model chip shortens ids (`claude-sonnet-5-20250707` → `Sonnet 5`). On pre-2.1.205 Claude Code (no model/context fields) rows show `[name] 23s`.
+  - **Width policy**: rows fit the panel's `columns` (with a small margin); drop order model → bar → elapsed, minimum `[name] 41%`, name truncation with ellipsis; percentage colors use the same 60/85 bands as the main context bar. Task names are control-character-stripped before embedding (terminal-escape injection guard).
+  - **Zero side effects**: subagent rendering never touches `_normalize`, git, caches, or the daily-spend ledger — the hook fires once per refresh tick per panel. Pinned by a test.
+  - **Install funnel**: `--setup` gains an opt-in question that writes the key (theme-propagated); `--install` prints the ready-to-paste snippet; `--uninstall` removes a claude-status-owned `subagentStatusLine`; `--print-config` gains a 9th `subagent=` line (appended — key=value parsers keep working; exact-8-line-count parsers need a one-line update); `--doctor` reports the hook's config state.
+  - Design went through two adversarial reviews before implementation (which set the envelope-only payload discriminator — `tasks: []` is a valid subagent payload; malformed elements can never flip the mode — and the never-empty-content rule) plus the standard four-agent review after.
+
+### Notes
+
+- **#91 closes as completed-with-delta**: it asked for a subagent runtime timer in the *main statusline's* agent section; the elapsed timer ships in the *agent panel* rows instead, because upstream provides `startTime` only on the subagent hook — the main-hook data #91 hoped for never materialized.
+- The main statusline is completely unchanged unless you add the new settings key.
+- 704 tests pass (+51: discriminator matrix, JSONL shape/purity incl. subprocess-level pins for both modes, id-type preservation, status matrix, startTime format bands incl. bool rejection, width drop-order and narrow-panel honesty, NaN-id invalid-JSONL guard, control-char stripping, model-shortener matrix, all-themes sweep, zero-side-effects pins at BOTH the renderer and the main() dispatch level, the full install-funnel matrix — hook install/preserve/corrupt-settings, uninstall foreign-hook/sub-only/stale-.bak scenarios, print-config variants — and the print-config 9-line contract update). Pure stdlib, zero dependencies, as always.
+
 ## [0.12.0] - 2026-07-09
 
 ### Changed — ⚠️ the `budget` section's meaning is fixed (and its label changes)

--- a/README.md
+++ b/README.md
@@ -95,6 +95,24 @@ The setup wizard walks you through theme selection, budget configuration, and in
 | CC Version | `CC:2.1.197` | Claude Code application version |
 | Clock | `15:30` | Current time |
 
+### Per-Subagent Status Rows (v0.13.0+)
+
+When Claude Code runs subagents, its `subagentStatusLine` hook lets a command render each task's row in the agent panel. claude-status serves both hooks from one binary — add this next to your existing `statusLine` entry (same command, plus `--subagent`):
+
+```json
+"subagentStatusLine": {"type": "command", "command": "claude-status --subagent"}
+```
+
+Each running task then renders as:
+
+```
+[Explore] [███░░░░░] 41% · 23s · Sonnet 5
+```
+
+— task name, context usage (bar + percentage, colored with the same 60/85% bands as the main context bar), elapsed time, and model. Segments degrade independently and drop in a fixed order (model → bar → elapsed) on narrow panels; finished tasks keep Claude Code's default rendering. Uses your `--theme` if you pass the same one as your statusLine command.
+
+**Version notes:** the per-task `model` and context fields require Claude Code **2.1.205+** — on older versions rows show `[name] 23s`. The `subagentStatusLine` setting's own minimum version isn't documented upstream; if an older Claude Code warns about an unknown settings key, remove the entry.
+
 ## Themes
 
 8 built-in themes to match your terminal aesthetic. Preview all live with `claude-status --demo`. Screenshots below show each theme rendered with one fixed dark palette — themes select ANSI colors; your own terminal palette supplies the exact hues.
@@ -152,7 +170,7 @@ claude-status --setup
 
 ### What `--setup` does
 
-Walks you through theme selection with a compact preview, optional budget configuration, and writes the statusLine entry to `~/.claude/settings.json`. Preserves all your existing settings.
+Walks you through theme selection with a compact preview, optional budget configuration, an optional per-subagent status rows question (see below), and writes the statusLine entry to `~/.claude/settings.json`. Preserves all your existing settings.
 
 > **Command not found?** Ensure your Python scripts directory is in `PATH`.
 > Fallback: `python -m claude_statusline --setup`
@@ -180,6 +198,7 @@ For full agent recipes (themes, budget, verification, uninstall, troubleshooting
 | `claude-status --print-config` | Show current install state in machine-readable form (for scripts/agents) |
 | `claude-status --demo` | Preview all 8 themes with sample data |
 | `claude-status --doctor` | Diagnostics: Python version, OS, terminal, current settings |
+| `claude-status --subagent` | Render per-subagent task rows (used by the `subagentStatusLine` hook, not run by hand — see Per-Subagent Status Rows) |
 | `claude-status --version` | Show version |
 | `claude-status --help` | Show usage |
 
@@ -327,6 +346,8 @@ If claude-status doesn't appear after installation:
 3. Ensure your Python scripts directory is in your `PATH`
 4. Try `python -m claude_statusline --setup` as a fallback
 5. Restart Claude Code after any configuration change
+
+**Why don't I see per-subagent rows?** In likely order: (1) rows only exist **while subagents are running** — an idle session shows nothing, that's normal; (2) check `~/.claude/settings.json` has the `subagentStatusLine` entry (`claude-status --doctor` reports its state); (3) your Claude Code version may predate the hook — the per-task model/context fields need 2.1.205+; (4) restart Claude Code after adding the entry; (5) probe the renderer directly: `claude-status --subagent < payload.json` with a captured payload prints the JSONL rows it would emit.
 
 ## Uninstall
 

--- a/claude_statusline/__init__.py
+++ b/claude_statusline/__init__.py
@@ -1,3 +1,3 @@
 """claude-status: Beautiful status line for Claude Code."""
 
-__version__ = "0.12.0"
+__version__ = "0.13.0"

--- a/claude_statusline/cli.py
+++ b/claude_statusline/cli.py
@@ -14,7 +14,7 @@ import tempfile
 import time
 
 from . import __version__
-from .bar import render_bar
+from .bar import _bar_color, render_bar
 from . import colors as _colors_mod
 from .colors import (
     BOLD, BRIGHT_BLACK, BRIGHT_MAGENTA, BRIGHT_RED, CYAN, GREEN, RED, RESET,
@@ -31,6 +31,7 @@ from .git import (
 from .sessions import (
     _CLAUDE_DIR, _CLAUDE_DIR_REAL, _VALID_EFFORT_LEVELS,
     _canonical_effort, _count_activity_with_status,
+    _parse_iso8601_ms,
     _read_cache, _write_cache,
     get_budget_config, get_budget_scope, get_clickable_links_enabled,
     get_compaction_threshold,
@@ -1981,6 +1982,294 @@ def render(data, theme_name="default"):
     return "\n".join(lines)
 
 
+# ─── subagentStatusLine support (v0.13.0, #110) ──────────────────────
+#
+# Claude Code's `subagentStatusLine` settings hook feeds a command
+# `columns` + a `tasks[]` array on stdin and renders each emitted
+# JSONL line `{"id": <task id>, "content": <row body>}` as that
+# task's row in the agent panel. One binary serves both hooks:
+# `claude-status --subagent` is the documented interface; a payload
+# arriving on the plain command is auto-detected as a convenience
+# fallback (stderr breadcrumb suggests the flag).
+
+# Terminal task statuses: rows are emitted only for tasks that are
+# (or may be) running. Omitting the id for finished tasks hands the
+# row back to upstream's default rendering — and kills the
+# forever-ticking elapsed timer a finished task would otherwise show.
+# Upstream's status enum is not documented; this set is deliberately
+# broad and matching is case-insensitive. Unknown/missing status
+# fails OPEN (render): wrongly rendering a live row for a new
+# terminal status is a cosmetic staleness bug, while wrongly hiding
+# running tasks would gut the feature.
+_TERMINAL_TASK_STATUSES = frozenset({
+    "completed", "complete", "done", "failed", "error", "errored",
+    "cancelled", "canceled", "aborted", "success", "succeeded",
+    "finished", "killed", "timeout", "timed_out",
+})
+
+# Free text from task definitions is embedded into terminal output —
+# strip C0/C1 control characters so a task name can't smuggle escape
+# sequences into the user's terminal (same threat model as the OSC 8
+# URL sanitizer above).
+_CONTROL_CHARS_RE = re.compile(r"[\x00-\x1f\x7f-\x9f]")
+
+# Trailing date stamp on model IDs ("claude-sonnet-5-20250707").
+_MODEL_DATE_RE = re.compile(r"-\d{8}$")
+
+_SUBAGENT_NAME_MAX = 24         # name segment cap (with ellipsis)
+_SUBAGENT_COLUMNS_DEFAULT = 80  # when columns is garbage after tasks qualified
+_SUBAGENT_COLUMNS_MARGIN = 2    # upstream may spend row budget on its own glyphs
+_SUBAGENT_ELAPSED_MAX_MS = 7 * 24 * 3600 * 1000  # >7d elapsed = garbage clock
+
+
+def _is_subagent_payload(data):
+    """Envelope-only discriminator for subagentStatusLine payloads.
+
+    True iff `tasks` is a LIST and `columns` is numeric (bool
+    excluded — it passes isinstance(int)). Deliberately nothing else:
+
+    - `tasks: []` (no agents running) IS a subagent payload — the
+      correct output is nothing, not a full ANSI statusline dumped
+      into the JSONL panel.
+    - Malformed ELEMENTS never flip the mode: element validation
+      happens per-row in render_subagent with skip, because one bad
+      task turning the whole payload into cross-mode corruption is
+      the worst available failure.
+    - There is no documented discriminator field upstream; this
+      inference (tasks + columns together) is the narrowest signal
+      the documented schema provides. A future MAIN payload growing
+      both keys would misroute — the --subagent flag exists so
+      correctly-configured users never depend on this inference.
+    """
+    if not isinstance(data, dict):
+        return False
+    if not isinstance(data.get("tasks"), list):
+        return False
+    cols = data.get("columns")
+    if isinstance(cols, bool):
+        return False
+    return _safe_num(cols) is not None
+
+
+def _parse_start_time_ms(value):
+    """Task startTime -> epoch ms, or None. Format is NOT documented
+    upstream, so accept the three plausible encodings:
+
+    - ISO-8601 string ("2026-07-09T18:00:00.000Z") via the transcript
+      timestamp parser.
+    - Epoch numbers, disambiguated by magnitude: < 1e11 -> seconds
+      (1e11 s is year 5138), 1e11..1e14 -> milliseconds (1e11 ms is
+      1973), >= 1e14 -> microseconds-or-garbage, rejected. The bands
+      cannot collide for ~3000 years.
+    - Numeric strings coerce via _safe_num (which also kills
+      NaN/Infinity — both valid json.loads output). Bools are
+      rejected explicitly (same rule as columns: bool is an int
+      subclass and `true` is not a timestamp).
+    """
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, str):
+        iso = _parse_iso8601_ms(value)
+        if iso is not None:
+            return iso
+    num = _safe_num(value)
+    if num is None or num <= 0:
+        return None
+    if num < 1e11:
+        return int(num * 1000)
+    if num < 1e14:
+        return int(num)
+    return None
+
+
+def _sanitize_row_text(value):
+    """Control-char-stripped, length-capped text for row embedding."""
+    if not isinstance(value, str):
+        return ""
+    text = _CONTROL_CHARS_RE.sub("", value).strip()
+    if len(text) > _SUBAGENT_NAME_MAX:
+        text = text[:_SUBAGENT_NAME_MAX - 1] + "…"
+    return text
+
+
+def _short_model(model_id):
+    """Compact display for a task's model id: "claude-sonnet-5-20250707"
+    -> "Sonnet 5", "claude-opus-4-8" -> "Opus 4.8". Trailing numeric
+    id parts are version components, joined with dots. Unknown shapes
+    degrade to the sanitized, dash-split, title-cased raw id.
+
+    Control-strip WITHOUT the length cap first: _sanitize_row_text's
+    24-char truncation would eat the trailing "-YYYYMMDD" before the
+    date regex could strip it ("claude-haiku-4-5-20251001" is 25
+    chars). The cap is applied to the final short form instead."""
+    if not isinstance(model_id, str):
+        return ""
+    text = _CONTROL_CHARS_RE.sub("", model_id).strip()
+    if not text:
+        return ""
+    text = _MODEL_DATE_RE.sub("", text)
+    if text.startswith("claude-"):
+        text = text[len("claude-"):]
+    parts = [p for p in text.split("-") if p]
+    version = []
+    while parts and parts[-1].isdigit():
+        version.insert(0, parts.pop())
+    family = " ".join(parts).title()
+    if family and version:
+        short = "{} {}".format(family, ".".join(version))
+    else:
+        short = family or ".".join(version)
+    if len(short) > _SUBAGENT_NAME_MAX:
+        short = short[:_SUBAGENT_NAME_MAX - 1] + "…"
+    return short
+
+
+def render_subagent(data, theme_name="default", _now=None):
+    """Render a subagentStatusLine payload to JSONL row overrides.
+
+    Contract (documented upstream): one `{"id", "content"}` JSON
+    object per line; a task whose id is omitted keeps its default
+    rendering; empty content HIDES a row. Consequences honored here:
+
+    - A task we cannot render (non-dict, no id, terminal status, or
+      nothing fits the width) is OMITTED — default rendering always
+      beats a hidden or garbled row. Empty content is never emitted:
+      a degradation path must not blank the user's panel.
+    - The id is echoed back as its ORIGINAL JSON value (int stays
+      int) so upstream's row matching cannot miss.
+    - ZERO disk writes and zero subprocess spawns happen here: this
+      never calls _normalize (which mirrors the effort cache to
+      disk), never touches git, and never records daily spend. The
+      hook fires once per refresh tick per panel — side effects would
+      multiply.
+
+    Row shape, fitted to `columns` minus a small margin (upstream may
+    spend part of the budget on its own glyphs — unverified):
+
+        [Explore] [███░░░░░] 41% · 23s · Sonnet 5
+
+    Drop order under width pressure: model -> bar -> elapsed; the
+    minimum row is "[name] 41%" (or "[name] 23s" on pre-2.1.205
+    payloads, which omit model/contextWindowSize). Percent color uses
+    the same 60/85 bands as the main context bar, so the panel and
+    the statusline agree on what "danger" looks like.
+    """
+    theme = get_theme(theme_name)
+    tc = theme["colors"]
+    now_ms = int((time.time() if _now is None else _now) * 1000)
+
+    # Trust any small positive width: a genuinely narrow panel must
+    # get a narrow budget (rows that can't fit are OMITTED — upstream's
+    # default rendering is the honest degrade). Falling back to the
+    # 80-col default for small values would invert the contract: a
+    # 19-col panel would receive 78-col rows, overflowing 3x. The
+    # default is reserved for genuine garbage (missing/non-positive/
+    # absurd).
+    cols = data.get("columns")
+    cols_num = None if isinstance(cols, bool) else _safe_num(cols)
+    if cols_num is None or cols_num <= 0 or cols_num > 4000:
+        width_budget = _SUBAGENT_COLUMNS_DEFAULT
+    else:
+        width_budget = int(cols_num)
+    width_budget -= _SUBAGENT_COLUMNS_MARGIN
+
+    lines = []
+    for task in data.get("tasks", []):
+        if not isinstance(task, dict):
+            continue
+        task_id = task.get("id")
+        if task_id is None:
+            continue
+
+        status = task.get("status")
+        if isinstance(status, str) and \
+                status.strip().lower() in _TERMINAL_TASK_STATUSES:
+            continue  # finished: upstream's default row, no live timer
+
+        name = ""
+        for key in ("name", "label", "type"):
+            name = _sanitize_row_text(task.get(key))
+            if name:
+                break
+        if not name:
+            name = "task"
+        name_seg = colorize("[{}]".format(name), tc["agent"])
+
+        # Context percentage: tokenCount may legitimately be 0 (a 0%
+        # bar); contextWindowSize must be strictly positive (guards
+        # ZeroDivision). Displayed pct clamps to 100 — upstream lag
+        # can put tokenCount above the window and "[####] 412%" is a
+        # lie either way (same rationale as the rate-limits clamp).
+        tokens = _safe_num(task.get("tokenCount"))
+        ctx = _safe_num(task.get("contextWindowSize"))
+        pct_seg = bar_seg = None
+        if tokens is not None and tokens >= 0 and ctx is not None and ctx > 0:
+            pct = min(100.0, (tokens / ctx) * 100.0)
+            pct_seg = colorize("{:.0f}%".format(pct), _bar_color(pct))
+            bar_seg = render_bar(pct, width=8, theme=theme)
+
+        # Elapsed: negative (future startTime / clock skew) and
+        # absurd (>7d) ages drop the segment — cache_age precedent.
+        elapsed_seg = None
+        start_ms = _parse_start_time_ms(task.get("startTime"))
+        if start_ms is not None:
+            age_ms = now_ms - start_ms
+            if 0 <= age_ms <= _SUBAGENT_ELAPSED_MAX_MS:
+                elapsed_seg = colorize(fmt_duration(age_ms), tc["value"])
+
+        model_seg = None
+        short = _short_model(task.get("model"))
+        if short:
+            model_seg = colorize(short, tc.get("model", BRIGHT_BLACK))
+
+        # Assemble at full detail, then drop model -> bar -> elapsed
+        # until the row fits. Never pad; never emit an empty row.
+        def _assemble(with_model, with_bar, with_elapsed):
+            parts = [name_seg]
+            gauge = " ".join(p for p in (
+                bar_seg if with_bar else None, pct_seg) if p)
+            if gauge:
+                parts.append(gauge)
+            if with_elapsed and elapsed_seg:
+                parts.append(elapsed_seg)
+            if with_model and model_seg:
+                parts.append(model_seg)
+            head = parts[0]
+            rest = parts[1:]
+            if not rest:
+                return head
+            return head + " " + " · ".join(rest)
+
+        row = None
+        for wm, wb, we in ((True, True, True), (False, True, True),
+                           (False, False, True), (False, False, False)):
+            candidate = _assemble(wm, wb, we)
+            if _visible_width(candidate) <= width_budget:
+                row = candidate
+                break
+        if row is None:
+            # Even "[name]"/"[name] 41%" overflows: truncate the name
+            # harder; if that still can't fit, omit the row entirely.
+            bare = colorize("[{}]".format(name[:8]), tc["agent"])
+            if _visible_width(bare) <= width_budget:
+                row = bare
+            else:
+                continue
+
+        # allow_nan=False + skip: a NaN/Infinity float id (json.loads
+        # accepts the bare literals) would otherwise serialize as
+        # `{"id": NaN, ...}` — invalid strict JSON that upstream's
+        # JSON.parse throws on, potentially poisoning EVERY row in the
+        # response. One bad task must never take down the panel.
+        try:
+            lines.append(json.dumps(
+                {"id": task_id, "content": row}, allow_nan=False))
+        except ValueError:
+            continue
+
+    return "\n".join(lines)
+
+
 def _demo_data():
     """Generate sample data for demo mode using the real nested schema.
 
@@ -2188,9 +2477,12 @@ def cmd_print_config():
     """Print current install state in a deterministic key=value form.
 
     Designed for coding agents and shell scripts. Output is a stable
-    8-line block — fields are always emitted in the same order, every
-    field always appears, and values containing newlines are
-    sanitized so the line count stays fixed.
+    9-line block (8 original lines + `subagent`, appended in v0.13.0
+    so existing key=value and first-8-lines parsers keep working; a
+    parser asserting an exact 8-line count does need updating) —
+    fields are always emitted in the same order, every field always
+    appears, and values containing newlines are sanitized so the line
+    count stays fixed.
 
     Output keys (in order):
       installed         true | false
@@ -2201,6 +2493,10 @@ def cmd_print_config():
       version           running module version
       settings_path     absolute path to the settings.json we inspected
       settings_state    ok | missing | unreadable
+      subagent          installed | installed_missing_flag | not_installed
+                        (state of the subagentStatusLine hook; the
+                        _missing_flag variant means the hook points at
+                        claude-status but lacks --subagent)
 
     Exit codes:
       0  installed (statusLine.command launches claude-status)
@@ -2221,6 +2517,7 @@ def cmd_print_config():
     refresh = ""
     theme = ""
     settings_state = "missing"
+    settings = None  # stays None when the settings file doesn't exist
 
     if os.path.exists(settings_file):
         try:
@@ -2275,6 +2572,18 @@ def cmd_print_config():
                     installed = True
                     theme = _extract_theme(parts)
 
+    # subagentStatusLine state (v0.13.0): appended as an EXTRA line
+    # after the original 8 so existing key=value parsers keep working;
+    # the docstring documents the addition.
+    subagent_state = "not_installed"
+    if isinstance(settings, dict):
+        sub = settings.get("subagentStatusLine")
+        if isinstance(sub, dict) and \
+                "claude-status" in str(sub.get("command", "")):
+            subagent_state = ("installed"
+                              if "--subagent" in str(sub.get("command", ""))
+                              else "installed_missing_flag")
+
     print("installed={}".format("true" if installed else "false"))
     print("command={}".format(_sanitize_field(cmd_str)))
     print("type={}".format(_sanitize_field(sl_type)))
@@ -2283,9 +2592,70 @@ def cmd_print_config():
     print("version={}".format(__version__))
     print("settings_path={}".format(_sanitize_field(settings_file)))
     print("settings_state={}".format(settings_state))
+    print("subagent={}".format(subagent_state))
     if settings_state == "unreadable":
         sys.exit(2)
     sys.exit(0 if installed else 1)
+
+
+def _subagent_command(theme_name="default"):
+    """The settings.json command string for the subagent hook —
+    same construction as the statusLine command, plus --subagent."""
+    cmd = "claude-status"
+    if theme_name != "default":
+        cmd += " --theme {}".format(theme_name)
+    return cmd + " --subagent"
+
+
+def _install_subagent_hook(theme_name="default"):
+    """Write the subagentStatusLine key into settings.json.
+
+    Returns True on success. Read-modify-ATOMIC-write (tmp +
+    os.replace); deliberately makes NO .bak of its own — the only
+    caller is the --setup wizard's opt-in question, which runs
+    seconds after cmd_install already created settings.json.bak.
+    Never called unconditionally: the setting's minimum Claude Code
+    version is undocumented upstream, and interactive setup is where
+    the user can check their version.
+    """
+    settings_file = _settings_path()
+    settings = {}
+    if os.path.exists(settings_file):
+        try:
+            with open(settings_file, "r", encoding="utf-8") as f:
+                settings = json.load(f)
+            if not isinstance(settings, dict):
+                settings = {}
+        except (json.JSONDecodeError, IOError) as e:
+            print("  Warning: could not read settings: {}".format(e))
+            return False
+    settings["subagentStatusLine"] = {
+        "type": "command",
+        "command": _subagent_command(theme_name),
+    }
+    # Atomic write (tmp + os.replace, the ledger/cache pattern): a
+    # disk-full mid-dump on a plain open() would leave settings.json
+    # truncated mid-JSON — corrupting the user's Claude Code config is
+    # the #96 incident class and never acceptable from a wizard step.
+    tmp = settings_file + ".tmp"
+    try:
+        os.makedirs(os.path.dirname(settings_file), exist_ok=True)
+        with open(tmp, "w", encoding="utf-8") as f:
+            json.dump(settings, f, indent=2)
+            f.write("\n")
+        os.replace(tmp, settings_file)
+    except OSError as e:
+        try:
+            os.unlink(tmp)
+        except OSError:
+            pass
+        print("  Warning: could not write settings: {}".format(e))
+        print("  Your settings.json was NOT modified (atomic write "
+              "failed before replace); a .bak from the install step "
+              "may also exist alongside it.")
+        return False
+    print("  subagentStatusLine: {}".format(_subagent_command(theme_name)))
+    return True
 
 
 def cmd_install(theme_name="default"):
@@ -2332,6 +2702,13 @@ def cmd_install(theme_name="default"):
     print("  statusLine: {}".format(cmd))
     print()
     print("Restart Claude Code to see your new status line!")
+    print()
+    print("Optional — per-subagent status rows in the agent panel")
+    print("(model/context fields need Claude Code 2.1.205+). Add to")
+    print("your settings.json, or run claude-status --setup:")
+    print()
+    print('  "subagentStatusLine": {{"type": "command", '
+          '"command": "{}"}}'.format(_subagent_command(theme_name)))
 
 
 def cmd_uninstall():
@@ -2355,14 +2732,36 @@ def cmd_uninstall():
         print("Error: could not read {}: {}".format(settings_file, e))
         return
 
-    if "statusLine" not in settings:
+    if "statusLine" not in settings and "subagentStatusLine" not in settings:
         print("claude-status is not installed (no statusLine in settings).")
         return
 
-    # Check for backup with previous statusLine config
+    # Remove the subagent hook if it points at claude-status —
+    # shipping an installer for a key the uninstaller strands would
+    # be a bug. A subagentStatusLine belonging to some other tool is
+    # left alone.
+    had_statusline = "statusLine" in settings
+    removed_sub = False
+    sub = settings.get("subagentStatusLine")
+    if isinstance(sub, dict) and "claude-status" in str(sub.get("command", "")):
+        del settings["subagentStatusLine"]
+        removed_sub = True
+
+    if not had_statusline and not removed_sub:
+        # Only a FOREIGN subagentStatusLine exists: nothing of ours to
+        # remove. Don't rewrite (and reformat) the user's settings, and
+        # don't print a false "Removed statusLine" message.
+        print("claude-status is not installed "
+              "(the subagentStatusLine present belongs to another tool).")
+        return
+
+    # Check for backup with previous statusLine config. Gated on the
+    # settings actually HAVING had a statusLine: without the gate, a
+    # subagent-hook-only uninstall against a stale .bak would resurrect
+    # a statusLine the user had deliberately removed.
     backup_file = settings_file + ".bak"
     restored = False
-    if os.path.exists(backup_file):
+    if had_statusline and os.path.exists(backup_file):
         try:
             with open(backup_file, "r", encoding="utf-8") as f:
                 backup = json.load(f)
@@ -2377,7 +2776,9 @@ def cmd_uninstall():
                   file=sys.stderr)
 
     if not restored:
-        del settings["statusLine"]
+        # pop, not del: this path also serves subagent-hook-only
+        # payloads where "statusLine" is legitimately absent.
+        settings.pop("statusLine", None)
 
     try:
         with open(settings_file, "w", encoding="utf-8") as f:
@@ -2387,10 +2788,12 @@ def cmd_uninstall():
         print("Error writing settings: {}".format(e))
         return
 
+    if removed_sub:
+        print("Removed subagentStatusLine hook.")
     if restored:
         print("Restored previous statusLine config from backup.")
         print("  statusLine: {}".format(settings.get("statusLine")))
-    else:
+    elif had_statusline:
         print("Removed statusLine from {}".format(settings_file))
 
     print()
@@ -2524,12 +2927,31 @@ def cmd_setup():
     print()
     cmd_install(theme_choice)
 
+    # Step 4b: optional per-subagent rows (v0.13.0). Opt-in question
+    # rather than unconditional write: --setup is interactive, so the
+    # user can check their Claude Code version; the setting's own
+    # minimum version is not documented upstream, and writing an
+    # unknown settings key on an old Claude Code may surface warnings.
+    subagent_enabled = False
+    try:
+        sub_input = input(
+            "Also enable per-subagent status rows in the agent panel?\n"
+            "  (task name, context %, elapsed — model/context need "
+            "Claude Code 2.1.205+) [y/N]: "
+        ).strip().lower()
+    except (EOFError, KeyboardInterrupt):
+        sub_input = ""
+    if sub_input in ("y", "yes"):
+        subagent_enabled = _install_subagent_hook(theme_choice)
+
     # Step 5: Summary
     print()
     print("Setup complete!")
     print("  Theme: {}".format(theme_choice))
     if budget is not None:
         print("  Budget: ${:.2f}/day".format(budget))
+    if subagent_enabled:
+        print("  Subagent rows: enabled")
     print()
     print("Tip: Add \"refreshInterval\": 10 to your statusLine config")
     print("     for periodic updates (clock, sessions, rate limits).")
@@ -2573,6 +2995,19 @@ def cmd_doctor():
                 settings = json.load(f)
             sl = settings.get("statusLine", "(not configured)")
             print("  statusLine: {}".format(sl))
+            sub = settings.get("subagentStatusLine")
+            if sub is None:
+                print("  subagentStatusLine: (not configured — per-task "
+                      "agent rows disabled; see README)")
+            else:
+                print("  subagentStatusLine: {}".format(sub))
+                if isinstance(sub, dict) and \
+                        "claude-status" in str(sub.get("command", "")) and \
+                        "--subagent" not in str(sub.get("command", "")):
+                    print("    note: command lacks --subagent — "
+                          "auto-detection covers it, but emits a "
+                          "per-tick stderr reminder; add the flag to "
+                          "silence it")
             if isinstance(sl, dict):
                 ri = sl.get("refreshInterval")
                 if ri:
@@ -2785,6 +3220,9 @@ def main():
     parser.add_argument("--print-config", action="store_true",
                         dest="print_config",
                         help="Print install state in machine-readable form (for scripts/agents)")
+    parser.add_argument("--subagent", action="store_true",
+                        help="Render subagentStatusLine task rows (JSONL) "
+                             "instead of the statusline")
     parser.add_argument("--theme", default="default",
                         choices=["default", "minimal", "powerline",
                                  "nord", "tokyo-night", "gruvbox", "rose-pine",
@@ -2820,15 +3258,50 @@ def main():
         return
 
     # Normal mode: read JSON from stdin, output statusline
+    raw = ""  # pre-bind: stdin.read() itself can raise ValueError
+    # (io.UnsupportedOperation on a closed stdin IS a ValueError
+    # subclass), and the handler below dereferences `raw`.
     try:
         raw = sys.stdin.read()
         if not raw.strip():
             return
         data = json.loads(raw)
     except (json.JSONDecodeError, ValueError):
-        print("?")
+        # JSONL purity: in subagent mode (or anything that even LOOKS
+        # like a truncated subagent payload) a bare "?" line would be
+        # injected into the agent panel's JSONL stream. Print nothing
+        # there; keep the long-standing "?" for the main hook.
+        # '"tasks":' (with colon) so only a KEY position matches — a
+        # truncated MAIN payload whose git branch is literally named
+        # "tasks" must still get its long-standing "?".
+        if not args.subagent and '"tasks":' not in (raw or ""):
+            print("?")
+        else:
+            print("claude-status: undecodable subagent payload",
+                  file=sys.stderr)
         return
     except KeyboardInterrupt:
+        return
+
+    # subagentStatusLine dispatch — BEFORE render()/_normalize, which
+    # have side effects (effort-cache mirror, git subprocesses, spend
+    # ledger) that must never run on the per-tick subagent hook.
+    # --subagent is the documented interface; auto-detection is a
+    # convenience fallback for users who pasted the bare command.
+    if args.subagent or _is_subagent_payload(data):
+        if not args.subagent:
+            print("claude-status: subagent payload auto-detected; "
+                  "prefer \"claude-status --subagent\" in "
+                  "subagentStatusLine settings", file=sys.stderr)
+        try:
+            output = render_subagent(data, args.theme) \
+                if _is_subagent_payload(data) else ""
+        except Exception as exc:
+            print("claude-status: subagent render error: {}".format(exc),
+                  file=sys.stderr)
+            output = ""
+        if output:
+            print(output)
         return
 
     try:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "claude-status"
-version = "0.12.0"
+version = "0.13.0"
 description = "Beautiful, informative status line for Claude Code — zero dependencies, cross-platform"
 readme = "README.md"
 license = {text = "MIT"}

--- a/tests/test_all.py
+++ b/tests/test_all.py
@@ -3912,11 +3912,13 @@ class TestPrintConfig(unittest.TestCase):
                     kv[k] = v
             return kv, exit_code
 
-    def test_emits_all_eight_keys_in_stable_order(self):
-        """Output contract: 8 keys, always in this exact order.
+    def test_emits_all_keys_in_stable_order(self):
+        """Output contract: 9 keys, always in this exact order
+        (`subagent` APPENDED in v0.13.0 — appending keeps pre-existing
+        8-line parsers working; inserting or reordering would not).
 
         Agents and shell scripts parse this — silent reordering or
-        adding/removing keys would break every downstream consumer.
+        removing keys would break every downstream consumer.
         """
         import claude_statusline.cli as cli_mod
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -3943,7 +3945,8 @@ class TestPrintConfig(unittest.TestCase):
         self.assertEqual(
             keys_in_order,
             ["installed", "command", "type", "refreshInterval",
-             "theme", "version", "settings_path", "settings_state"],
+             "theme", "version", "settings_path", "settings_state",
+             "subagent"],
             "key order or set changed — agents parsing this output will break"
         )
 
@@ -4256,15 +4259,16 @@ class TestPrintConfigEdgeCases(unittest.TestCase):
     def test_newline_in_command_does_not_break_line_count(self):
         """A command containing \\n would inject a fake key=value line
         into the output, breaking every parser that relies on the
-        documented 8-line contract. Sanitization must convert it to a
+        documented fixed-line contract (9 lines since v0.13.0 added
+        the subagent field). Sanitization must convert it to a
         single space."""
         kv, code, stdout_text, _ = self._run_with_settings({
             "statusLine": {"type": "command",
                            "command": "claude-status\nPWNED=evil"}
         })
-        # Exactly 8 lines, regardless of injected content.
-        self.assertEqual(len(stdout_text.strip().split("\n")), 8,
-            "newline in command field broke the 8-line contract")
+        # Exactly 9 lines, regardless of injected content.
+        self.assertEqual(len(stdout_text.strip().split("\n")), 9,
+            "newline in command field broke the 9-line contract")
         # PWNED should NOT appear as a key — it should be folded into
         # the command value (with the newline replaced by space).
         self.assertNotIn("PWNED", kv,
@@ -4295,7 +4299,7 @@ class TestPrintConfigEdgeCases(unittest.TestCase):
             "corrupt settings must exit 2 so agents do not overwrite recoverable config")
         # Diagnostic on stderr — agent's logs need to know why.
         self.assertIn("settings.json", stderr_text)
-        # 8 lines on stdout still — contract preserved even on error.
+        # 9 lines on stdout still — contract preserved even on error.
         self.assertEqual(kv["installed"], "false")
 
     # ── Gemini review fixes: versioned python, last-theme-wins, nulls
@@ -8192,6 +8196,585 @@ class TestCostBreakdownSection(unittest.TestCase):
         self.assertIsNone(n["cost"],
             "total_cost_usd absent must result in cost=None (existing "
             "contract — cost sections hide cleanly)")
+
+
+# ─── subagentStatusLine (v0.13.0, #110) ──────────────────────────────
+
+class TestSubagentDiscriminator(unittest.TestCase):
+    """Envelope-only payload discrimination. tasks=[] IS a subagent
+    payload; element contents can never flip the mode; bool columns
+    rejected (bool is an int subclass)."""
+
+    def _is(self, data):
+        from claude_statusline.cli import _is_subagent_payload
+        return _is_subagent_payload(data)
+
+    def test_canonical_subagent_payload(self):
+        self.assertTrue(self._is({"tasks": [{"id": "t"}], "columns": 100}))
+
+    def test_empty_tasks_is_subagent(self):
+        """No agents running is a legit subagent payload — falling
+        through to main would dump a full ANSI statusline into the
+        JSONL panel (the worst cross-mode corruption)."""
+        self.assertTrue(self._is({"tasks": [], "columns": 80}))
+
+    def test_malformed_elements_do_not_flip_mode(self):
+        self.assertTrue(self._is(
+            {"tasks": ["garbage", {"no": "id"}, 42], "columns": 80}))
+
+    def test_main_payload_is_not_subagent(self):
+        self.assertFalse(self._is({"session_id": "x", "cost": {}}))
+
+    def test_bool_columns_rejected(self):
+        self.assertFalse(self._is({"tasks": [], "columns": True}))
+
+    def test_missing_columns_rejected(self):
+        self.assertFalse(self._is({"tasks": []}))
+
+    def test_numeric_string_columns_accepted(self):
+        self.assertTrue(self._is({"tasks": [], "columns": "120"}))
+
+    def test_non_dict_payloads(self):
+        for bad in (None, [], "x", 42):
+            self.assertFalse(self._is(bad))
+
+
+class TestSubagentRender(unittest.TestCase):
+    """render_subagent: JSONL shape, degradation, sanitization,
+    width policy, and the zero-side-effects contract."""
+
+    def setUp(self):
+        # ONE clock for fixtures AND rendering: fmt_duration floors,
+        # so a >=1s gap between fixture-build time and render time
+        # would flip "23s" to "24s" — the clock-gap flake class fixed
+        # in the v0.12 tests. Every fixture startTime and every render
+        # derives from self._now.
+        self._now = time.time()
+
+    def _plain(self, s):
+        return re.sub(r"\x1b\[[0-9;]*m", "", s)
+
+    def _rows(self, payload, theme="default", now=None):
+        import claude_statusline.cli as cli_mod
+        out = cli_mod.render_subagent(
+            payload, theme, _now=self._now if now is None else now)
+        if not out:
+            return []
+        return [json.loads(line) for line in out.split("\n")]
+
+    def _task(self, **over):
+        base = {"id": "t1", "name": "Explore", "status": "running",
+                "startTime": int((self._now - 23) * 1000),
+                "tokenCount": 410_000, "model": "claude-sonnet-5-20250707",
+                "contextWindowSize": 1_000_000}
+        base.update(over)
+        return base
+
+    def test_full_row_shape(self):
+        rows = self._rows({"columns": 100, "tasks": [self._task()]})
+        self.assertEqual(len(rows), 1)
+        self.assertEqual(rows[0]["id"], "t1")
+        body = self._plain(rows[0]["content"])
+        self.assertIn("[Explore]", body)
+        self.assertIn("41%", body)
+        self.assertIn("23s", body)
+        self.assertIn("Sonnet 5", body)
+
+    def test_id_type_preserved(self):
+        """Int id echoes as int — stringifying could break upstream
+        row matching, silently default-rendering the row."""
+        rows = self._rows({"columns": 100, "tasks": [self._task(id=42)]})
+        self.assertEqual(rows[0]["id"], 42)
+        self.assertIsInstance(rows[0]["id"], int)
+
+    def test_terminal_status_omitted(self):
+        """Finished tasks are omitted (default rendering) — a rendered
+        row would show a forever-ticking elapsed timer."""
+        for status in ("completed", "FAILED", "Cancelled", "done",
+                       "succeeded", "error"):
+            rows = self._rows(
+                {"columns": 100, "tasks": [self._task(status=status)]})
+            self.assertEqual(rows, [], status)
+
+    def test_unknown_status_renders(self):
+        """Fail OPEN: unknown/missing status renders — wrongly hiding
+        running tasks would gut the feature."""
+        for status in ("thinking", None, 42, ""):
+            payload = {"columns": 100, "tasks": [self._task(status=status)]}
+            self.assertEqual(len(self._rows(payload)), 1, repr(status))
+
+    def test_never_empty_content(self):
+        """Empty content HIDES a row upstream — degradation must OMIT
+        instead. At columns=5 (budget 3) even the bare truncated name
+        cannot fit: the row must be omitted entirely, never emitted
+        with empty content."""
+        rows = self._rows({"columns": 5,
+                           "tasks": [self._task(name="A" * 200)]})
+        self.assertEqual(rows, [])
+        # At a moderate width the bare truncated-name fallback renders.
+        rows = self._rows({"columns": 14,
+                           "tasks": [self._task(name="A" * 200)]})
+        self.assertEqual(len(rows), 1)
+        self.assertTrue(rows[0]["content"])
+        self.assertIn("[AAAAAAAA]", self._plain(rows[0]["content"]))
+
+    def test_malformed_tasks_skipped_good_ones_render(self):
+        payload = {"columns": 100, "tasks": [
+            "garbage", {"name": "no-id"}, self._task(), 42]}
+        rows = self._rows(payload)
+        self.assertEqual([r["id"] for r in rows], ["t1"])
+
+    def test_zero_tokens_renders_zero_pct(self):
+        """tokenCount=0 is a legit just-started task — truthiness
+        gates drop zeros (house rule)."""
+        rows = self._rows({"columns": 100,
+                           "tasks": [self._task(tokenCount=0)]})
+        self.assertIn("0%", self._plain(rows[0]["content"]))
+
+    def test_zero_ctx_no_gauge_no_crash(self):
+        rows = self._rows({"columns": 100,
+                           "tasks": [self._task(contextWindowSize=0)]})
+        body = self._plain(rows[0]["content"])
+        self.assertNotIn("%", body)
+        self.assertIn("[Explore]", body)
+
+    def test_overflow_pct_clamped(self):
+        rows = self._rows({"columns": 100, "tasks": [
+            self._task(tokenCount=5_000_000, contextWindowSize=1_000_000)]})
+        self.assertIn("100%", self._plain(rows[0]["content"]))
+        self.assertNotIn("500%", self._plain(rows[0]["content"]))
+
+    def test_start_time_formats(self):
+        from claude_statusline.cli import _parse_start_time_ms
+        self.assertEqual(_parse_start_time_ms(1_783_046_343),
+                         1_783_046_343_000)          # epoch seconds
+        self.assertEqual(_parse_start_time_ms(1_783_046_343_072),
+                         1_783_046_343_072)          # epoch ms
+        self.assertIsNotNone(_parse_start_time_ms("2026-07-09T18:00:00Z"))
+        self.assertEqual(_parse_start_time_ms("1783046343"),
+                         1_783_046_343_000)          # numeric string
+        for bad in (1e15, -5, 0, None, "garbage", float("nan"),
+                    float("inf"), [], {}):
+            self.assertIsNone(_parse_start_time_ms(bad), repr(bad))
+
+    def test_future_and_ancient_start_time_drop_elapsed(self):
+        now = time.time()
+        for start in (int((now + 300) * 1000),           # future: skew
+                      int((now - 30 * 86400) * 1000)):   # 30d: garbage
+            rows = self._rows(
+                {"columns": 100, "tasks": [self._task(startTime=start)]},
+                now=now)
+            body = self._plain(rows[0]["content"])
+            self.assertNotIn("s ·", body + " ·")  # no elapsed segment
+            self.assertIn("41%", body)            # rest of row intact
+
+    def test_control_chars_stripped_from_name(self):
+        rows = self._rows({"columns": 100, "tasks": [
+            self._task(name="Ex\x1b]0;pwn\x07plore")]})
+        self.assertNotIn("\x1b]", self._plain(rows[0]["content"]))
+        self.assertNotIn("\x07", rows[0]["content"])
+
+    def test_width_drop_order(self):
+        """model drops first, then bar, then elapsed; minimum keeps
+        name + colored pct."""
+        task = self._task()
+        wide = self._plain(self._rows(
+            {"columns": 120, "tasks": [task]})[0]["content"])
+        self.assertIn("Sonnet 5", wide)
+        mid = self._plain(self._rows(
+            {"columns": 40, "tasks": [task]})[0]["content"])
+        self.assertNotIn("Sonnet 5", mid)
+        self.assertIn("41%", mid)
+        narrow = self._plain(self._rows(
+            {"columns": 25, "tasks": [task]})[0]["content"])
+        self.assertIn("[Explore]", narrow)
+        self.assertIn("41%", narrow)
+        self.assertNotIn("█", narrow)  # bar dropped before pct
+
+    def test_garbage_columns_defaults_not_flips(self):
+        """Garbage columns uses the default width — the renderer must
+        NOT crash and must still emit the row (unconditional length
+        assertion: an empty result here would BE the regression)."""
+        for cols in ("abc", -5, 0, 10**9, None):
+            payload = {"columns": cols, "tasks": [self._task()]}
+            rows = self._rows(payload)
+            self.assertEqual(len(rows), 1, repr(cols))
+            self.assertTrue(rows[0]["content"])
+
+    def test_numeric_string_columns_honored(self):
+        """The discriminator accepts columns "120"; the renderer must
+        use it as a real width (118 budget), not the default."""
+        rows = self._rows({"columns": "120", "tasks": [self._task()]})
+        self.assertEqual(len(rows), 1)
+        self.assertIn("Sonnet 5", self._plain(rows[0]["content"]))
+
+    def test_name_fallback_chain(self):
+        for task, expected in (
+            ({"id": "a", "label": "MyLabel"}, "[MyLabel]"),
+            ({"id": "b", "type": "explore"}, "[explore]"),
+            ({"id": "c"}, "[task]"),
+        ):
+            rows = self._rows({"columns": 80, "tasks": [task]})
+            self.assertIn(expected, self._plain(rows[0]["content"]))
+
+    def test_all_builtin_themes_render(self):
+        """A theme with a missing color key would crash render_subagent
+        (bracket indexing) — and main() would silently blank the whole
+        panel. Pin every built-in theme end to end."""
+        for theme in ("default", "minimal", "powerline", "nord",
+                      "tokyo-night", "gruvbox", "rose-pine", "focus"):
+            rows = self._rows({"columns": 100, "tasks": [self._task()]},
+                              theme=theme)
+            self.assertEqual(len(rows), 1, theme)
+            self.assertIn("[Explore]", self._plain(rows[0]["content"]))
+
+    def test_short_model_matrix(self):
+        from claude_statusline.cli import _short_model
+        self.assertEqual(_short_model("claude-sonnet-5-20250707"), "Sonnet 5")
+        self.assertEqual(_short_model("claude-opus-4-8"), "Opus 4.8")
+        self.assertEqual(_short_model("claude-haiku-4-5-20251001"),
+                         "Haiku 4.5")
+        self.assertEqual(_short_model("mystery-model"), "Mystery Model")
+        self.assertEqual(_short_model(""), "")
+        self.assertEqual(_short_model(None), "")
+        self.assertEqual(_short_model(42), "")
+
+    def test_empty_tasks_renders_nothing(self):
+        self.assertEqual(self._rows({"columns": 80, "tasks": []}), [])
+
+    def test_nan_id_row_skipped_not_invalid_jsonl(self):
+        """A NaN float id (json.loads accepts the bare literal) must
+        skip the row — json.dumps would emit `{"id": NaN}` which is
+        invalid strict JSON and could poison the whole panel response
+        upstream."""
+        rows = self._rows({"columns": 100, "tasks": [
+            self._task(id=float("nan")),
+            self._task(id="good", name="Other")]})
+        self.assertEqual([r["id"] for r in rows], ["good"])
+
+    def test_narrow_panel_gets_narrow_budget(self):
+        """A genuinely narrow panel (cols=12) must NOT fall back to
+        the 80-col default — that would hand a 12-col panel 78-col
+        rows (3x overflow). Rows that can't fit are omitted; short
+        names still render."""
+        rows = self._rows({"columns": 12, "tasks": [self._task(name="Ex")]})
+        if rows:  # short name fits: must respect the narrow budget
+            from claude_statusline.cli import _visible_width
+            self.assertLessEqual(_visible_width(rows[0]["content"]), 10)
+        # A long-name task at the same width is omitted, not overflowed.
+        rows2 = self._rows({"columns": 12,
+                            "tasks": [self._task(name="VeryLongAgentName")]})
+        for r in rows2:
+            from claude_statusline.cli import _visible_width
+            self.assertLessEqual(_visible_width(r["content"]), 10)
+
+    def test_zero_side_effects(self):
+        """Subagent rendering must never write to disk or record
+        spend — the hook fires per refresh tick per panel."""
+        import claude_statusline.cli as cli_mod
+        calls = []
+        orig_wc = cli_mod._write_cache
+        orig_rec = cli_mod.record_and_get_daily_spend
+        cli_mod._write_cache = lambda *a, **k: calls.append("write_cache")
+        cli_mod.record_and_get_daily_spend = \
+            lambda *a, **k: calls.append("ledger") or (0.0, False)
+        try:
+            self._rows({"columns": 100, "tasks": [self._task()],
+                        "session_id": "parent", "effort": {"level": "high"},
+                        "cost": {"total_cost_usd": 5.0}})
+        finally:
+            cli_mod._write_cache = orig_wc
+            cli_mod.record_and_get_daily_spend = orig_rec
+        self.assertEqual(calls, [],
+            "subagent rendering must be side-effect free")
+
+    def test_main_dispatch_skips_normalize_entirely(self):
+        """The REAL invariant: main()'s dispatch must route a subagent
+        payload BEFORE _normalize/render ever run (_normalize itself
+        writes the effort cache; render spawns git). Pins the dispatch
+        ORDER, not just render_subagent's own purity."""
+        import claude_statusline.cli as cli_mod
+        from io import StringIO
+        calls = []
+        orig_norm = cli_mod._normalize
+        orig_branch = cli_mod.get_branch
+        cli_mod._normalize = lambda d: calls.append("normalize") or {}
+        cli_mod.get_branch = lambda: calls.append("git") or ""
+        payload = json.dumps({"columns": 100, "tasks": [self._task()],
+                              "effort": {"level": "high"}})
+        old_stdin, old_stdout = sys.stdin, sys.stdout
+        old_argv = sys.argv
+        sys.stdin = StringIO(payload)
+        sys.stdout = StringIO()
+        sys.argv = ["claude-status", "--subagent"]
+        try:
+            cli_mod.main()
+            out = sys.stdout.getvalue()
+        finally:
+            sys.stdin, sys.stdout = old_stdin, old_stdout
+            sys.argv = old_argv
+            cli_mod._normalize = orig_norm
+            cli_mod.get_branch = orig_branch
+        self.assertEqual(calls, [],
+            "_normalize/git must never run on the subagent hook")
+        self.assertIn('"id"', out)  # the JSONL actually rendered
+
+    def test_bool_start_time_rejected(self):
+        """bool is an int subclass; `true` is not a timestamp — same
+        explicit rejection rule as columns."""
+        from claude_statusline.cli import _parse_start_time_ms
+        self.assertIsNone(_parse_start_time_ms(True))
+        self.assertIsNone(_parse_start_time_ms(False))
+
+
+class TestSubagentEndToEnd(unittest.TestCase):
+    """Subprocess-level: the --subagent flag, auto-detection fallback,
+    and the JSONL stdout-purity contract."""
+
+    _env = None
+
+    @classmethod
+    def setUpClass(cls):
+        cls._env = os.environ.copy()
+        cls._env["PYTHONIOENCODING"] = "utf-8"
+        cls._env.pop("CLAUDE_STATUSLINE_WIDTH", None)
+
+    def _run(self, args, payload):
+        return subprocess.run(
+            [sys.executable, "-m", "claude_statusline"] + args,
+            input=payload, capture_output=True, timeout=10,
+            env=self._env, encoding="utf-8", errors="replace",
+            cwd=os.path.join(os.path.dirname(__file__), ".."),
+        )
+
+    def _payload(self):
+        return json.dumps({"columns": 100, "tasks": [
+            {"id": "t1", "name": "Explore", "status": "running",
+             "startTime": int((time.time() - 23) * 1000),
+             "tokenCount": 410_000, "model": "claude-sonnet-5",
+             "contextWindowSize": 1_000_000}]})
+
+    def test_flag_renders_jsonl(self):
+        r = self._run(["--subagent"], self._payload())
+        self.assertEqual(r.returncode, 0)
+        lines = [l for l in r.stdout.strip().split("\n") if l]
+        self.assertEqual(len(lines), 1)
+        obj = json.loads(lines[0])
+        self.assertEqual(obj["id"], "t1")
+        self.assertIn("Explore", obj["content"])
+
+    def test_flag_garbage_stdin_prints_nothing(self):
+        """JSONL purity: with --subagent, undecodable stdin must not
+        emit the main hook's '?' fallback."""
+        r = self._run(["--subagent"], "{truncated")
+        self.assertEqual(r.stdout.strip(), "")
+        self.assertEqual(r.returncode, 0)
+
+    def test_flag_main_payload_prints_nothing(self):
+        """--subagent with a non-subagent payload outputs nothing,
+        exit 0 — never a statusline into the JSONL panel."""
+        r = self._run(["--subagent"],
+                      json.dumps({"session_id": "x", "git_branch": "main"}))
+        self.assertEqual(r.returncode, 0)
+        self.assertEqual(r.stdout.strip(), "")
+
+    def test_autodetect_fallback_with_breadcrumb(self):
+        r = self._run([], self._payload())
+        self.assertEqual(r.returncode, 0)
+        obj = json.loads(r.stdout.strip().split("\n")[0])
+        self.assertEqual(obj["id"], "t1")
+        self.assertIn("--subagent", r.stderr)
+
+    def test_truncated_subagent_garbage_no_question_mark(self):
+        """A truncated payload that LOOKS subagent-shaped must not put
+        a bare '?' into the panel even without the flag."""
+        r = self._run([], '{"tasks": [{"id": "t1"')
+        self.assertEqual(r.stdout.strip(), "")
+
+    def test_main_mode_unaffected(self):
+        r = self._run([], json.dumps(
+            {"git_branch": "main",
+             "context_window": {"used_percentage": 30}}))
+        self.assertEqual(r.returncode, 0)
+        self.assertNotIn('"id"', r.stdout)
+        self.assertIn("[", r.stdout)  # the context bar
+
+    def test_main_mode_garbage_still_question_mark(self):
+        """The main hook's long-standing '?' contract is preserved for
+        payloads that don't look subagent-shaped. Exact match — any
+        other output would also have contained a '?' under assertIn."""
+        r = self._run([], "not json at all {{{")
+        self.assertEqual(r.stdout.strip(), "?")
+
+    def test_value_position_tasks_still_question_mark(self):
+        """The '?'-suppression sniff matches only the KEY position
+        ('"tasks":') — a truncated MAIN payload whose branch is
+        literally named "tasks" keeps its '?'."""
+        r = self._run([], '{"git_branch": "tasks", "cost"')
+        self.assertEqual(r.stdout.strip(), "?")
+
+
+class TestSubagentInstallFunnel(unittest.TestCase):
+    """The install/uninstall/print-config funnel for the
+    subagentStatusLine hook. All in-process with _settings_path
+    patched to a temp file — never the real settings.json (#96)."""
+
+    def setUp(self):
+        import claude_statusline.cli as cli_mod
+        self._cli = cli_mod
+        self._dir = tempfile.mkdtemp(prefix="claude-status-funnel-")
+        self._settings = os.path.join(self._dir, "settings.json")
+        self._orig_path = cli_mod._settings_path
+        cli_mod._settings_path = lambda: self._settings
+
+    def tearDown(self):
+        import shutil as shutil_mod
+        self._cli._settings_path = self._orig_path
+        shutil_mod.rmtree(self._dir, ignore_errors=True)
+
+    def _write(self, obj):
+        with open(self._settings, "w", encoding="utf-8") as f:
+            json.dump(obj, f)
+
+    def _read(self):
+        with open(self._settings, encoding="utf-8") as f:
+            return json.load(f)
+
+    def _capture(self, fn, *a):
+        from io import StringIO
+        old = sys.stdout
+        sys.stdout = StringIO()
+        try:
+            fn(*a)
+            return sys.stdout.getvalue()
+        finally:
+            sys.stdout = old
+
+    # --- _install_subagent_hook ---------------------------------------
+
+    def test_hook_install_fresh_file(self):
+        self._capture(self._cli._install_subagent_hook, "default")
+        s = self._read()
+        self.assertEqual(s["subagentStatusLine"]["command"],
+                         "claude-status --subagent")
+
+    def test_hook_install_preserves_existing_keys(self):
+        self._write({"statusLine": {"type": "command",
+                                    "command": "claude-status"},
+                     "otherKey": {"keep": True}})
+        self._capture(self._cli._install_subagent_hook, "nord")
+        s = self._read()
+        self.assertEqual(s["subagentStatusLine"]["command"],
+                         "claude-status --theme nord --subagent")
+        self.assertEqual(s["otherKey"], {"keep": True})
+        self.assertIn("statusLine", s)
+
+    def test_hook_install_unreadable_settings_returns_false(self):
+        with open(self._settings, "w") as f:
+            f.write("{corrupt json")
+        out_val = []
+        out = self._capture(
+            lambda: out_val.append(
+                self._cli._install_subagent_hook("default")))
+        self.assertFalse(out_val[0])
+        # File untouched — the corrupt original is preserved for the
+        # user to inspect, not clobbered.
+        with open(self._settings) as f:
+            self.assertEqual(f.read(), "{corrupt json")
+
+    # --- cmd_uninstall interactions -------------------------------------
+
+    def test_uninstall_removes_claude_status_sub_hook(self):
+        self._write({
+            "statusLine": {"type": "command", "command": "claude-status"},
+            "subagentStatusLine": {"type": "command",
+                                   "command": "claude-status --subagent"},
+        })
+        out = self._capture(self._cli.cmd_uninstall)
+        s = self._read()
+        self.assertNotIn("subagentStatusLine", s)
+        self.assertNotIn("statusLine", s)
+        self.assertIn("Removed subagentStatusLine hook.", out)
+
+    def test_uninstall_leaves_foreign_sub_hook(self):
+        """A subagentStatusLine belonging to another tool is not ours
+        to remove — and with no statusLine either, nothing is
+        rewritten and no false 'Removed' message prints."""
+        original = {"subagentStatusLine": {"type": "command",
+                                           "command": "other-tool"}}
+        self._write(original)
+        before = open(self._settings).read()
+        out = self._capture(self._cli.cmd_uninstall)
+        self.assertEqual(open(self._settings).read(), before,
+                         "settings must not be rewritten")
+        self.assertNotIn("Removed", out)
+
+    def test_uninstall_sub_hook_only_no_keyerror(self):
+        """Settings with ONLY a claude-status subagentStatusLine: the
+        pop-not-del path — a revert to `del settings["statusLine"]`
+        crashes exactly here."""
+        self._write({"subagentStatusLine": {
+            "type": "command", "command": "claude-status --subagent"}})
+        out = self._capture(self._cli.cmd_uninstall)
+        s = self._read()
+        self.assertEqual(s, {})
+        self.assertIn("Removed subagentStatusLine hook.", out)
+
+    def test_uninstall_sub_only_stale_bak_does_not_resurrect(self):
+        """A stale .bak containing an old statusLine must NOT be
+        restored when the live settings had no statusLine to remove —
+        the user deliberately removed it."""
+        self._write({"subagentStatusLine": {
+            "type": "command", "command": "claude-status --subagent"}})
+        with open(self._settings + ".bak", "w") as f:
+            json.dump({"statusLine": {"type": "command",
+                                      "command": "claude-status"}}, f)
+        self._capture(self._cli.cmd_uninstall)
+        self.assertNotIn("statusLine", self._read())
+
+    # --- print-config subagent variants ---------------------------------
+
+    def _print_config_lines(self):
+        from io import StringIO
+        old = sys.stdout
+        sys.stdout = StringIO()
+        try:
+            try:
+                self._cli.cmd_print_config()
+            except SystemExit:
+                pass
+            return sys.stdout.getvalue().strip().split("\n")
+        finally:
+            sys.stdout = old
+
+    def _subagent_line(self):
+        return [l for l in self._print_config_lines()
+                if l.startswith("subagent=")][0]
+
+    def test_print_config_subagent_installed(self):
+        self._write({"statusLine": {"type": "command",
+                                    "command": "claude-status"},
+                     "subagentStatusLine": {
+                         "type": "command",
+                         "command": "claude-status --subagent"}})
+        self.assertEqual(self._subagent_line(), "subagent=installed")
+
+    def test_print_config_subagent_missing_flag(self):
+        self._write({"subagentStatusLine": {
+            "type": "command", "command": "claude-status"}})
+        self.assertEqual(self._subagent_line(),
+                         "subagent=installed_missing_flag")
+
+    def test_print_config_subagent_not_installed_variants(self):
+        for settings in ({}, {"subagentStatusLine": "garbage"},
+                         {"subagentStatusLine": {"command": "other-tool"}}):
+            self._write(settings)
+            self.assertEqual(self._subagent_line(),
+                             "subagent=not_installed", repr(settings))
+
+    def test_print_config_subagent_no_settings_file(self):
+        # No file at all: settings stays None — must not crash.
+        self.assertEqual(self._subagent_line(), "subagent=not_installed")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

claude-status now serves Claude Code's **`subagentStatusLine`** hook ([#110](https://github.com/mkalkere/claude-statusline/issues/110), closes [#91](https://github.com/mkalkere/claude-statusline/issues/91)): each running subagent renders as

```
[Explore] [███░░░░░] 41% · 23s · Sonnet 5
```

— name, per-task context bar + percentage (same 60/85 color bands as the main bar), elapsed, model — in the agent panel. One binary serves both hooks:

```json
"subagentStatusLine": {"type": "command", "command": "claude-status --subagent"}
```

## Contract discipline

- **`--subagent` is the documented interface**; auto-detection (envelope-only discriminator: `tasks` list + numeric `columns`; `tasks: []` is a valid payload; malformed elements can never flip the mode) covers bare-command configs with a stderr note.
- **JSONL purity is hard**: every subagent-mode error path prints nothing; the main hook's `?` fallback is suppressed for anything that even looks like a truncated subagent payload; ids echo as their original JSON type; NaN/Infinity ids are skipped (`allow_nan=False`) so one bad task can never invalidate the panel's whole response; rows that degrade to nothing are **omitted** — empty content (which hides a row upstream) is never emitted.
- **Status-aware**: finished tasks keep Claude Code's default rendering — no forever-ticking elapsed timers. Unknown statuses fail open.
- **`startTime` undocumented upstream** → accepts ISO-8601 / epoch-seconds / epoch-ms (magnitude-banded, collision-free for ~3000 years), drops on clock skew or >7-day ages.
- **Zero side effects**, pinned at both the renderer and the `main()` dispatch level (the hook fires per refresh tick — `_normalize`'s effort-cache write and git subprocesses must never run there).

## Install funnel

`--setup` opt-in question (atomic settings write), `--install` prints the snippet + version caveat, `--uninstall` removes a claude-status-owned hook (foreign hooks untouched; stale-`.bak` statusLine resurrection gated off), `--print-config` gains a 9th `subagent=` line (appended — key=value parsers unaffected), `--doctor` reports hook state.

## Review record

2 adversarial **design** reviews before any code (set the envelope discriminator, the never-empty-content rule, the no-TTL parsing rules) + the standard 4-agent review after. Post-review fixes include: a NameError on closed stdin, a columns floor inversion (a 19-col panel got 78-col rows), model-id shortening that mangled real 25-char ids (`claude-haiku-4-5-20251001`), a NaN-id invalid-JSONL emitter, an uninstall path that resurrected deleted statusLines from stale backups, and non-atomic settings writes from the wizard.

## Honest unknowns (documented in README)

- The `subagentStatusLine` setting's own minimum Claude Code version is not documented upstream (2.1.205+ is pinned only for the per-task model/context fields; pre-2.1.205 rows show `[name] 23s`).
- Whether upstream prefixes its own glyphs inside the row budget is unverified — rows leave a 2-col margin, and release notes ask for visual feedback.

## Testing

**704 tests pass (+51)**: discriminator matrix, JSONL shape/purity with subprocess-level pins for both modes, id-type preservation, status matrix, startTime bands incl. bool rejection, width drop-order + narrow-panel honesty, model-shortener matrix, all-8-themes sweep, dual-level zero-side-effects pins, and the full install-funnel matrix (hook install/preserve/corrupt-settings, uninstall foreign/sub-only/stale-.bak, print-config variants). Pure stdlib, zero dependencies. Main statusline untouched unless the new key is added.