### PR TITLE
feat: context_tokens (ctx:412K/1M) + setup star-ask + token-field hardening

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,28 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.14.0] - 2026-07-16
+
+### Added
+
+- **`context_tokens` section** ([#113](https://github.com/mkalkere/claude-statusline/issues/113)) — absolute context display, `ctx:412K/1M`. At 1M-token windows a percentage hides magnitude: 40% means ~400K tokens re-billed on every turn. Opt-in via custom theme, droppable under width pressure.
+
+  - **Derived, not read**: the numerator is `used_percentage × context_window_size` rather than the raw token fields. `used_percentage` is upstream's authoritative fill signal and already drives the bar and `!CTX`, so deriving keeps the chip arithmetically consistent with the bar beside it — a 42% bar next to a chip implying 41.2% would read as a bug. The input/cache token components are ambiguous as a fill measure (their sum is not the documented fill).
+  - Percentage clamped to [0, 100] (the bar's own bounds), so an out-of-spec upstream value can't render `ctx:2.5M/1M`. Hidden when either signal is missing or garbage; `0%` legitimately renders `ctx:0/1M` (zeros are values, not absences).
+
+- **Star-ask epilogue in `--setup`** ([#114](https://github.com/mkalkere/claude-statusline/issues/114)) — one polite line after a successful wizard run pointing at the GitHub repo. Success path only (aborted setup prints nothing extra), `--setup` only (`--install` is the agents/CI path where no human reads output), no tracking, no repetition mechanism.
+
+### Fixed
+
+- **`used_percentage: NaN` blanked the entire statusline.** `json.loads` accepts bare `NaN`, and the context/token fields flowed raw through `_normalize` — NaN passed every `is not None` gate and detonated in `render_bar`'s `int()`. The whole context/token block (`used_percentage`, `input_tokens`, `output_tokens`, `cache_read`, `cache_create`) now gets the same treatment the money/time trio received in v0.11.0 — `_safe_num` coercion at the `_normalize` chokepoint plus the stderr breadcrumb for present-but-garbage values: garbage becomes `None` (section hides), numeric strings coerce and render, zeros survive as zeros. Found by this release's own hidden-when-garbage test matrix — the third time a new feature's test probes have caught a pre-existing stdin-reachable crash (v0.11: cost/duration; v0.13: closed-stdin NameError; now this).
+
+### Notes
+
+- Test-infra: four stale 5-second subprocess timeouts bumped to 15s — the suite now spawns more subprocess tests (the star-ask contract tests), and Windows process cold-start under load intermittently exceeded 5s, intermittently failing an unrelated pre-existing test (three of ten local runs under load). Load-dependent flakes violate the determinism rule regardless of which test they bite.
+- **Derived chips refuse corrupted inputs**: `cache %`, `burn`, and `speed` sum token components with an absent-means-0 rule; coercion would have let a present-but-garbage component be silently zeroed, rendering a confidently-wrong ratio (a cache hit-rate inflating 60% → 90% with no visible cue — reproduced in review). A `token_fields_corrupt` flag now hides those three chips whenever any component was present-but-garbage; genuinely-absent fields keep the longstanding absent-means-0 behavior.
+- **`context_tokens` rounds, not floors** — float representation error puts e.g. `1M × 4.1%` at 40999.999…, and a bare `int()` rendered `ctx:40K` where the exact value is 41K. Also: a custom theme setting `context_tokens: null` now degrades to the default color via `_first()` (house convention) instead of crashing the line, and a failed budget save during `--setup` no longer reports the unsaved budget in the completion summary.
+- 727 tests pass (+23 net; 2 POSIX-only permission pins skip on Windows and run on the Linux/macOS CI legs: derivation/clamp/zero/hidden matrices for the new chip, droppable membership, the NaN-blanks-line regression with the full coercion matrix, and the star-ask's three contract points — exactly-once on success, absent on abort, absent from `--install`). Pure stdlib, zero dependencies, as always.
+
 ## [0.13.0] - 2026-07-09
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ The setup wizard walks you through theme selection, budget configuration, and in
 | Cost Rate | `~$3.6/hr` | Projected session cost per hour (session average, includes idle time; the `~` marks it as a projection). Hidden for sessions under a minute. Opt-in via custom theme. |
 | Rate Limits | `5h:34% 7d:18% ~2h` | API usage limits with reset countdown (Pro/Max only) |
 | Context Size | `(1M)` | Know if you're on a 200K or 1M context window |
+| Context Tokens | `ctx:412K/1M` | Absolute context usage — at 1M windows a percentage hides magnitude (40% ≈ 400K tokens re-billed every turn). Derived from the same signal as the bar (with a configured compaction threshold the bar rescales its fill toward the compaction point; the chip always shows the raw window fraction). Opt-in via custom theme. |
 | Context Warning | `!CTX` | Bold red alert at 85%+ context usage |
 
 ### Line 2 — Session Context

--- a/claude_statusline/__init__.py
+++ b/claude_statusline/__init__.py
@@ -1,3 +1,3 @@
 """claude-status: Beautiful status line for Claude Code."""
 
-__version__ = "0.13.0"
+__version__ = "0.14.0"

--- a/claude_statusline/cli.py
+++ b/claude_statusline/cli.py
@@ -182,17 +182,54 @@ def _normalize(data):
     cu = cw.get("current_usage") or {}
     flat_usage = data.get("current_usage") or {}
 
-    out["used_percentage"] = _first(cw.get("used_percentage"), flat_usage.get("used_percentage"))
-    out["input_tokens"] = _first(cu.get("input_tokens"), flat_usage.get("input_tokens"))
-    out["output_tokens"] = _first(cu.get("output_tokens"), flat_usage.get("output_tokens"))
-    out["cache_read"] = _first(
+    # _safe_num on the whole context/token block — same chokepoint
+    # treatment the money/time trio received in v0.11.0, applied here
+    # in v0.14.0 after a probe showed `used_percentage: NaN` (a valid
+    # json.loads literal, so stdin-reachable) sailing through the
+    # `is not None` gates into render_bar's int() and blanking the
+    # entire statusline. Garbage becomes None; every consumer already
+    # treats None as "hide". Numeric strings coerce and render.
+    #
+    # `token_fields_corrupt` preserves the absent-vs-garbage
+    # distinction the coercion would otherwise destroy: the DERIVED
+    # chips (cache %, burn, speed) sum these fields with an
+    # absent-means-0 rule, and silently zeroing a component that
+    # upstream DID send (but garbled) would render confidently-wrong
+    # ratios — a cache hit-rate inflated from 60% to 90% with no
+    # visible cue (silent-failure review, reproduced). Those chips
+    # hide when this flag is set; per-field sections (tokens, bar)
+    # keep their own per-field visibility.
+    def _coerce_token(field, raw):
+        num = _safe_num(raw)
+        if raw is not None and num is None:
+            out["token_fields_corrupt"] = True
+            # Same stderr breadcrumb as the money/time trio's
+            # _num_or_note: present-but-garbage must leave a
+            # diagnostic trail, not vanish silently.
+            print(
+                "claude-status: ignoring non-numeric {} value".format(field),
+                file=sys.stderr,
+            )
+        return num
+
+    out["token_fields_corrupt"] = False
+    out["used_percentage"] = _coerce_token(
+        "used_percentage",
+        _first(cw.get("used_percentage"), flat_usage.get("used_percentage")))
+    out["input_tokens"] = _coerce_token(
+        "input_tokens",
+        _first(cu.get("input_tokens"), flat_usage.get("input_tokens")))
+    out["output_tokens"] = _coerce_token(
+        "output_tokens",
+        _first(cu.get("output_tokens"), flat_usage.get("output_tokens")))
+    out["cache_read"] = _coerce_token("cache_read", _first(
         cu.get("cache_read_input_tokens"),
         flat_usage.get("cache_read_tokens"),
-    )
-    out["cache_create"] = _first(
+    ))
+    out["cache_create"] = _coerce_token("cache_create", _first(
         cu.get("cache_creation_input_tokens"),
         flat_usage.get("cache_create_tokens"),
-    )
+    ))
     out["context_size"] = _first(
         cw.get("context_window_size"),
         flat_usage.get("context_size"),
@@ -681,11 +718,18 @@ def _render_sections_named(n, order, theme):
             )
 
         elif section == "cache":
-            cache_str = fmt_cache_pct(cache_read, total_input)
-            if cache_str:
-                sections.append(
-                    colorize("cache:", tc["label"]) + colorize(cache_str, GREEN)
-                )
+            # Hidden when any token component was present-but-garbage
+            # (token_fields_corrupt): the ratio sums components with an
+            # absent-means-0 rule, and silently zeroing a component
+            # upstream DID send renders a confidently-wrong hit-rate
+            # (60% inflating to 90% with no visible cue — reproduced
+            # in review). An honest absence beats a plausible lie.
+            if not n.get("token_fields_corrupt"):
+                cache_str = fmt_cache_pct(cache_read, total_input)
+                if cache_str:
+                    sections.append(
+                        colorize("cache:", tc["label"]) + colorize(cache_str, GREEN)
+                    )
 
         elif section == "cost" and cost is not None:
             sections.append(colorize(fmt_cost(cost), tc["cost"]))
@@ -783,7 +827,11 @@ def _render_sections_named(n, order, theme):
 
                 sections.append(pr_text)
 
-        elif section == "burn" and total_tokens and duration:
+        elif section == "burn" and total_tokens and duration \
+                and not n.get("token_fields_corrupt"):
+            # corrupt-gate: same rationale as the cache section — a
+            # garbage component silently zeroed in total_tokens would
+            # understate the burn rate with no visible cue.
             rate = fmt_burn_rate(total_tokens, duration)
             if rate != "?":
                 sections.append(
@@ -800,7 +848,11 @@ def _render_sections_named(n, order, theme):
             )
 
         elif section == "speed":
-            speed_str = fmt_speed(total_tokens, api_duration)
+            # corrupt-gate: see the cache section.
+            if n.get("token_fields_corrupt"):
+                speed_str = ""
+            else:
+                speed_str = fmt_speed(total_tokens, api_duration)
             if speed_str:
                 spc = tc.get("speed", CYAN)
                 sections.append(
@@ -863,6 +915,38 @@ def _render_sections_named(n, order, theme):
             if cs:
                 sections.append(colorize(
                     "({})".format(fmt_tokens(int(cs))), BRIGHT_BLACK))
+
+        elif section == "context_tokens":
+            # Absolute context display "ctx:412K/1M" (#113). At 1M
+            # windows a percentage hides magnitude — 40% is ~400K
+            # tokens re-billed every turn. The numerator is DERIVED
+            # (used_percentage × window size), not read from the token
+            # fields: used_percentage is upstream's authoritative
+            # fill signal and already drives the bar and !CTX, so
+            # deriving keeps this chip arithmetically consistent with
+            # the bar beside it (a 42% bar next to a chip reading
+            # 41.2% of the window would look like a bug). The
+            # input/cache token components are ambiguous as a fill
+            # measure — their sum is not the documented fill.
+            # Hidden when either signal is missing/garbage. Percentage
+            # clamped to [0, 100] (same bounds the bar enforces) so an
+            # out-of-spec upstream pct can't render ctx:12M/1M.
+            cs = _safe_num(context_size)
+            p = _safe_num(pct)
+            if cs and cs > 0 and p is not None:
+                p = max(0.0, min(100.0, p))
+                # round(), not bare int(): float representation error
+                # puts e.g. 1_000_000 * 4.1 / 100.0 at 40999.999…, and
+                # flooring renders ctx:40K where the exact value is
+                # 41K (13 such off-by-a-chip cases verified across
+                # 0.1%-step percentages at a 1M window).
+                # _first() for the color so a custom theme setting
+                # `context_tokens: null` degrades to the default
+                # instead of crashing colorize() (house convention).
+                ctc = _first(tc.get("context_tokens"), BRIGHT_BLACK)
+                sections.append(colorize(
+                    "ctx:{}/{}".format(fmt_tokens(int(round(cs * p / 100.0))),
+                                       fmt_tokens(int(cs))), ctc))
 
         elif section == "ctx_warning":
             # Percentage-based warning — works for any context window size
@@ -1256,8 +1340,8 @@ _COMPACT_DROP = [
     "git_extras", "version", "cc_version", "clock", "worktree",
     "sessions", "tools", "activity", "cache_age", "latency", "context_size",
     "session_name", "rate_limits", "output_style", "added_dirs", "effort",
-    "git_worktree", "speed", "cost_rate", "git_state", "commit_age",
-    "cost_breakdown", "pr", "thinking",
+    "git_worktree", "speed", "cost_rate", "context_tokens", "git_state",
+    "commit_age", "cost_breakdown", "pr", "thinking",
 ]
 _NARROW_DROP = _COMPACT_DROP + [
     "cache", "burn", "lines", "budget", "agent", "model",
@@ -2922,6 +3006,9 @@ def cmd_setup():
             print("  Budget saved: ${:.2f}/day".format(budget))
         except OSError as e:
             print("  Warning: could not save budget config: {}".format(e))
+            # Reset so the Step-5 summary doesn't claim a budget that
+            # was never written — a masked-wrong success message.
+            budget = None
 
     # Step 4: Install statusLine config
     print()
@@ -2959,6 +3046,15 @@ def cmd_setup():
     print("Preview all themes: claude-status --demo")
     print("Diagnostics: claude-status --doctor")
     print("Uninstall: claude-status --uninstall")
+    # Star-ask epilogue (#114): printed ONLY here, on the interactive
+    # wizard's success path — never in --install (the agents/CI path,
+    # where no human reads it) and never interleaved with functional
+    # output. Successful installers are the only people who can grow
+    # the project's discoverability; one polite line, no tracking,
+    # no repetition mechanism.
+    print()
+    print("If claude-status is useful to you, a GitHub star helps")
+    print("others find it: https://github.com/mkalkere/claude-statusline")
 
 
 def cmd_doctor():

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "claude-status"
-version = "0.13.0"
+version = "0.14.0"
 description = "Beautiful, informative status line for Claude Code — zero dependencies, cross-platform"
 readme = "README.md"
 license = {text = "MIT"}

--- a/tests/test_all.py
+++ b/tests/test_all.py
@@ -1147,6 +1147,278 @@ class TestCacheDirPermissions(unittest.TestCase):
             shutil_mod.rmtree(tmp_root, ignore_errors=True)
 
 
+class TestContextTokensSection(unittest.TestCase):
+    """`context_tokens` (#113): absolute context display ctx:412K/1M.
+    Numerator DERIVED from used_percentage × window size so the chip
+    always agrees arithmetically with the bar beside it."""
+
+    def _plain(self, s):
+        return re.sub(r"\x1b\[[0-9;]*m", "", s)
+
+    def _chip(self, cw):
+        import claude_statusline.cli as cli_mod
+        orig_line2 = THEMES["default"]["line2"]
+        orig_branch = cli_mod.get_branch
+        cli_mod.get_branch = lambda: "main"
+        try:
+            THEMES["default"]["line2"] = ["context_tokens", "branch"]
+            out = self._plain(cli_mod.render(
+                {"git_branch": "main", "context_window": cw}, "default"))
+            m = re.search(r"ctx:\S+", out)
+            return m.group(0) if m else None
+        finally:
+            THEMES["default"]["line2"] = orig_line2
+            cli_mod.get_branch = orig_branch
+
+    def test_derived_from_pct_times_size(self):
+        self.assertEqual(
+            self._chip({"context_window_size": 1_000_000,
+                        "used_percentage": 42}), "ctx:420K/1M")
+
+    def test_200k_window(self):
+        self.assertEqual(
+            self._chip({"context_window_size": 200_000,
+                        "used_percentage": 85}), "ctx:170K/200K")
+
+    def test_zero_pct_renders_zero(self):
+        """0% is a legit value — must render ctx:0/1M, not hide
+        (the 'or drops zeros' house rule)."""
+        self.assertEqual(
+            self._chip({"context_window_size": 1_000_000,
+                        "used_percentage": 0}), "ctx:0/1M")
+
+    def test_out_of_spec_pct_clamped(self):
+        """pct 250 clamps to 100 — the chip must never read
+        ctx:2.5M/1M (same bounds the bar enforces)."""
+        self.assertEqual(
+            self._chip({"context_window_size": 1_000_000,
+                        "used_percentage": 250}), "ctx:1M/1M")
+
+    def test_hidden_when_either_signal_missing_or_garbage(self):
+        for cw in ({"context_window_size": 1_000_000},
+                   {"used_percentage": 42},
+                   {"context_window_size": "abc", "used_percentage": 42},
+                   {"context_window_size": 1_000_000,
+                    "used_percentage": "abc"},
+                   {"context_window_size": 1_000_000,
+                    "used_percentage": float("nan")},
+                   {"context_window_size": 0, "used_percentage": 42},
+                   {"context_window_size": -5, "used_percentage": 42},
+                   {}):
+            self.assertIsNone(self._chip(cw), repr(cw))
+
+    def test_negative_pct_clamps_to_zero(self):
+        """Pin the clamp's lower bound as a behavior choice."""
+        self.assertEqual(
+            self._chip({"context_window_size": 1_000_000,
+                        "used_percentage": -12}), "ctx:0/1M")
+
+    def test_string_pct_renders(self):
+        self.assertEqual(
+            self._chip({"context_window_size": 1_000_000,
+                        "used_percentage": "42"}), "ctx:420K/1M")
+
+    def test_context_tokens_is_compact_droppable(self):
+        from claude_statusline.cli import (
+            _COMPACT_DROP, _NARROW_DROP, _FIT_DROP_PRIORITY)
+        self.assertIn("context_tokens", _COMPACT_DROP)
+        self.assertIn("context_tokens", _NARROW_DROP)
+        self.assertIn("context_tokens", _FIT_DROP_PRIORITY)
+
+    def test_fractional_pct_rounds_not_floors(self):
+        """4.1% of 1M is exactly 41,000 — but float representation puts
+        1_000_000 * 4.1 / 100.0 at 40999.999…, and a bare int() floors
+        it to render ctx:40K. round() first (code-review finding: 13
+        such off-by-a-chip cases across 0.1%-step percentages)."""
+        self.assertEqual(
+            self._chip({"context_window_size": 1_000_000,
+                        "used_percentage": 4.1}), "ctx:41K/1M")
+        self.assertEqual(
+            self._chip({"context_window_size": 1_000_000,
+                        "used_percentage": 33.3}), "ctx:333K/1M")
+
+    def test_null_theme_color_degrades(self):
+        """A custom theme with `context_tokens: null` must fall to the
+        default color, not crash colorize (house _first convention —
+        this section is reachable ONLY via hand-edited theme JSON,
+        exactly where a user writes null)."""
+        import claude_statusline.cli as cli_mod
+        orig_line2 = THEMES["default"]["line2"]
+        orig_colors = THEMES["default"]["colors"]
+        orig_branch = cli_mod.get_branch
+        cli_mod.get_branch = lambda: "main"
+        try:
+            THEMES["default"]["line2"] = ["context_tokens", "branch"]
+            THEMES["default"]["colors"] = dict(orig_colors,
+                                               context_tokens=None)
+            out = self._plain(cli_mod.render(
+                {"git_branch": "main",
+                 "context_window": {"context_window_size": 1_000_000,
+                                    "used_percentage": 42}}, "default"))
+            self.assertIn("ctx:420K/1M", out)
+        finally:
+            THEMES["default"]["line2"] = orig_line2
+            THEMES["default"]["colors"] = orig_colors
+            cli_mod.get_branch = orig_branch
+
+
+class TestTokenCorruptGate(unittest.TestCase):
+    """Silent-failure review: coercing a present-but-garbage token
+    component to None must not let the DERIVED chips (cache %, burn,
+    speed) recompute with that component silently zeroed — a cache
+    hit-rate inflating 60% -> 90% with no visible cue. They hide
+    instead; per-field sections keep their own visibility."""
+
+    def _plain(self, s):
+        return re.sub(r"\x1b\[[0-9;]*m", "", s)
+
+    def _render(self, cw_usage):
+        import claude_statusline.cli as cli_mod
+        orig_branch = cli_mod.get_branch
+        cli_mod.get_branch = lambda: "main"
+        try:
+            return self._plain(cli_mod.render({
+                "git_branch": "main",
+                "context_window": {"used_percentage": 50,
+                                   "current_usage": cw_usage},
+                "cost": {"total_cost_usd": 0.5,
+                         "total_duration_ms": 300_000,
+                         "total_api_duration_ms": 60_000},
+            }, "default"))
+        finally:
+            cli_mod.get_branch = orig_branch
+
+    _VALID = {"input_tokens": 50_000, "output_tokens": 5_000,
+              "cache_read_input_tokens": 90_000,
+              "cache_creation_input_tokens": 10_000}
+
+    def test_all_valid_renders_derived_chips(self):
+        out = self._render(dict(self._VALID))
+        self.assertIn("cache:60%", out)
+        self.assertIn("burn:", out)
+
+    def test_garbage_component_hides_derived_not_wrong(self):
+        """Garbage input_tokens: cache % must HIDE (was: rendered a
+        confidently-wrong 90%). The tokens chip's own in:? remains the
+        visible cue."""
+        usage = dict(self._VALID, input_tokens="fifty-thousand")
+        out = self._render(usage)
+        self.assertNotIn("cache:", out)
+        self.assertNotIn("burn:", out)
+        self.assertIn("in:?", out)
+
+    def test_invisible_garbage_component_still_hides(self):
+        """The worst pre-fix case: garbage cache_creation only — every
+        visible field looked normal while cache % was wrong. Must hide
+        with no other cue available."""
+        usage = dict(self._VALID,
+                     cache_creation_input_tokens=float("nan"))
+        out = self._render(usage)
+        self.assertNotIn("cache:", out)
+        self.assertIn("in:50K", out)  # per-field sections unaffected
+
+    def test_absent_component_still_computes(self):
+        """ABSENT (never sent) stays the pre-existing absent-means-0
+        rule — only present-but-garbage trips the gate."""
+        usage = dict(self._VALID)
+        del usage["cache_creation_input_tokens"]
+        out = self._render(usage)
+        self.assertIn("cache:", out)
+
+    def test_normalize_flag(self):
+        from claude_statusline.cli import _normalize
+        n = _normalize({"context_window": {"current_usage":
+                       {"input_tokens": "abc"}}, "session_id": "x"})
+        self.assertTrue(n["token_fields_corrupt"])
+        n = _normalize({"context_window": {"current_usage":
+                       {"input_tokens": 5}}, "session_id": "x"})
+        self.assertFalse(n["token_fields_corrupt"])
+        n = _normalize({"session_id": "x"})  # all absent: not corrupt
+        self.assertFalse(n["token_fields_corrupt"])
+
+
+class TestContextFieldCoercion(unittest.TestCase):
+    """v0.14.0: the context/token block gets the same _safe_num
+    chokepoint treatment the money/time trio got in v0.11.0. Before
+    this, `used_percentage: NaN` (stdin-reachable — json.loads accepts
+    the bare literal) sailed through `is not None` gates into
+    render_bar's int() and blanked the ENTIRE statusline."""
+
+    def test_nan_pct_hides_bar_not_whole_line(self):
+        import claude_statusline.cli as cli_mod
+        orig_branch = cli_mod.get_branch
+        cli_mod.get_branch = lambda: "main"
+        try:
+            out = re.sub(r"\x1b\[[0-9;]*m", "", cli_mod.render({
+                "git_branch": "main",
+                "context_window": {"context_window_size": 1_000_000,
+                                   "used_percentage": float("nan")},
+                "cost": {"total_cost_usd": 0.5},
+            }, "default"))
+        finally:
+            cli_mod.get_branch = orig_branch
+        self.assertIn("$0.50", out)   # line survived
+        self.assertIn("main", out)
+
+    def test_normalize_coerces_context_block(self):
+        from claude_statusline.cli import _normalize
+        n = _normalize({"context_window": {
+            "used_percentage": "42",
+            "current_usage": {"input_tokens": "1000",
+                              "output_tokens": float("inf"),
+                              "cache_read_input_tokens": float("nan"),
+                              "cache_creation_input_tokens": [1]},
+        }, "session_id": "x"})
+        self.assertEqual(n["used_percentage"], 42.0)
+        self.assertEqual(n["input_tokens"], 1000.0)
+        self.assertIsNone(n["output_tokens"])
+        self.assertIsNone(n["cache_read"])
+        self.assertIsNone(n["cache_create"])
+
+    def test_zero_tokens_survive_coercion(self):
+        """0 is falsy but legit — coercion must return 0.0, not None."""
+        from claude_statusline.cli import _normalize
+        n = _normalize({"context_window": {
+            "used_percentage": 0,
+            "current_usage": {"input_tokens": 0}}, "session_id": "x"})
+        self.assertEqual(n["used_percentage"], 0.0)
+        self.assertEqual(n["input_tokens"], 0.0)
+
+    def test_numeric_strings_render_e2e(self):
+        """CHANGELOG claim pinned end to end: stringified numerics
+        coerce AND render — and do NOT trip the corrupt gate (they are
+        valid values, not garbage)."""
+        import claude_statusline.cli as cli_mod
+        orig_branch = cli_mod.get_branch
+        cli_mod.get_branch = lambda: "main"
+        try:
+            out = re.sub(r"\x1b\[[0-9;]*m", "", cli_mod.render({
+                "git_branch": "main",
+                "context_window": {
+                    "used_percentage": "42",
+                    "current_usage": {"input_tokens": "1000",
+                                      "output_tokens": "500",
+                                      "cache_read_input_tokens": "9000"}},
+            }, "default"))
+        finally:
+            cli_mod.get_branch = orig_branch
+        self.assertIn("in:1K", out)
+        self.assertIn("out:500", out)
+        self.assertIn("cache:", out)  # gate NOT tripped by strings
+
+    def test_builtin_themes_do_not_include_new_optin_sections(self):
+        """Pins the 'opt-in via custom theme' claim for context_tokens
+        (and cost_rate, which shared the missing pin): absent from
+        every built-in theme's line lists."""
+        for name, theme in THEMES.items():
+            for key, val in theme.items():
+                if re.match(r"line\d+$", key) and isinstance(val, list):
+                    self.assertNotIn("context_tokens", val,
+                                     "{}[{}]".format(name, key))
+                    self.assertNotIn("cost_rate", val,
+                                     "{}[{}]".format(name, key))
+
+
 class TestSafeNumFinite(unittest.TestCase):
     """_safe_num guarantees a FINITE float or None (v0.11.0). NaN in
     particular is poison: every comparison is False, so it sails
@@ -2250,7 +2522,7 @@ class TestSetupCommand(unittest.TestCase):
         """--setup flag should be recognized by argument parser."""
         result = subprocess.run(
             [sys.executable, "-m", "claude_statusline", "--setup"],
-            capture_output=True, timeout=5,
+            capture_output=True, timeout=15,
             input="1\n\n",  # choose default theme, skip budget
             encoding="utf-8", errors="replace",
             env={**os.environ, "PYTHONIOENCODING": "utf-8"},
@@ -4064,7 +4336,7 @@ class TestPrintConfig(unittest.TestCase):
             env.pop("CLAUDE_STATUSLINE_SETTINGS_PATH", None)
             r = subprocess.run(
                 [sys.executable, "-m", "claude_statusline", "--print-config"],
-                env=env, capture_output=True, text=True, timeout=5,
+                env=env, capture_output=True, text=True, timeout=15,
             )
             self.assertEqual(r.returncode, 0,
                 "expected exit 0 for installed state; got {}\nSTDOUT: {}\nSTDERR: {}".format(
@@ -4394,7 +4666,7 @@ class TestSetupWizardUpdated(unittest.TestCase):
         """--setup should be recognized."""
         result = subprocess.run(
             [sys.executable, "-m", "claude_statusline", "--setup"],
-            capture_output=True, timeout=5,
+            capture_output=True, timeout=15,
             input="1\n\n",
             encoding="utf-8", errors="replace",
             env={**os.environ, "PYTHONIOENCODING": "utf-8"},
@@ -4405,11 +4677,60 @@ class TestSetupWizardUpdated(unittest.TestCase):
         self.assertIn("full detail", result.stdout)
         self.assertIn("focus", result.stdout)
 
+    def test_setup_success_shows_star_ask(self):
+        """The star-ask epilogue (#114) prints once on the wizard's
+        success path. Input completes all prompts (theme 1, budget
+        skip, subagent skip via EOF-safe default)."""
+        result = subprocess.run(
+            [sys.executable, "-m", "claude_statusline", "--setup"],
+            capture_output=True, timeout=15,
+            input="1\n\nn\n",
+            encoding="utf-8", errors="replace",
+            env={**os.environ, "PYTHONIOENCODING": "utf-8"},
+        )
+        self.assertEqual(result.returncode, 0)
+        self.assertIn("Setup complete!", result.stdout)
+        self.assertEqual(
+            result.stdout.count("github.com/mkalkere/claude-statusline"), 1,
+            "star-ask must appear exactly once on success")
+        self.assertIn("a GitHub star helps", result.stdout)
+
+    def test_setup_abort_no_star_ask(self):
+        """Aborted setup (EOF at the first prompt) must NOT print the
+        star-ask — it's a success-path epilogue, not a nag."""
+        result = subprocess.run(
+            [sys.executable, "-m", "claude_statusline", "--setup"],
+            capture_output=True, timeout=15,
+            input="",
+            encoding="utf-8", errors="replace",
+            env={**os.environ, "PYTHONIOENCODING": "utf-8"},
+        )
+        # Positive control: the abort path actually ran (a startup
+        # crash would produce empty stdout and pass the NotIn
+        # assertion vacuously — test-analyzer finding).
+        self.assertEqual(result.returncode, 0)
+        self.assertIn("Setup cancelled.", result.stdout)
+        self.assertNotIn("a GitHub star helps", result.stdout)
+
+    def test_install_has_no_star_ask(self):
+        """--install is the agents/CI path — no human reads it, so no
+        star-ask there (design decision in #114)."""
+        result = subprocess.run(
+            [sys.executable, "-m", "claude_statusline", "--install"],
+            capture_output=True, timeout=15,
+            encoding="utf-8", errors="replace",
+            env={**os.environ, "PYTHONIOENCODING": "utf-8"},
+        )
+        # Positive control (same vacuity guard as the abort test).
+        self.assertEqual(result.returncode, 0)
+        self.assertIn("Installed claude-status into", result.stdout)
+        self.assertNotIn("a GitHub star helps", result.stdout)
+
     def test_uninstall_flag_accepted(self):
         """--uninstall should be recognized."""
         result = subprocess.run(
             [sys.executable, "-m", "claude_statusline", "--uninstall"],
-            capture_output=True, timeout=5,
+            capture_output=True, timeout=15,
             encoding="utf-8", errors="replace",
             env={**os.environ, "PYTHONIOENCODING": "utf-8"},
         )


### PR DESCRIPTION
## Summary

Two small features ([#113](https://github.com/mkalkere/claude-statusline/issues/113), [#114](https://github.com/mkalkere/claude-statusline/issues/114)) plus the hardening their test matrices surfaced.

**`context_tokens`** — opt-in absolute context display, `ctx:412K/1M`. At 1M windows a percentage hides magnitude (40% ≈ 400K tokens re-billed per turn). Derived from `used_percentage × window size` so it tracks the bar's own signal (derivation rationale in-code; the compaction-threshold rescaling nuance is documented rather than papered over). `round()` not floor — float representation error rendered `ctx:40K` for 4.1% of 1M (13 such cases verified). Clamped [0,100], `_first()` color fallthrough, droppable, pinned absent from every built-in theme.

**Star-ask epilogue** — one polite line at the end of a *successful* `--setup` run only. Absent from `--install` (agents/CI path) and aborted runs; three contract tests with positive controls (the negative tests previously could pass vacuously on a startup crash — review finding, fixed).

## Hardening

- **Pre-existing stdin-reachable crash**: `used_percentage: NaN` blanked the entire statusline via `render_bar`'s `int()`. The whole context/token block now gets the v0.11 chokepoint treatment — `_safe_num` coercion plus the stderr breadcrumb for present-but-garbage values. Second time a new feature's test probes have caught a pre-existing stdin-reachable crash.
- **Derived chips refuse corrupted inputs**: `cache %`/`burn`/`speed` sum token components with absent-means-0; a present-but-garbage component was silently zeroed, rendering a confidently-wrong ratio (cache 60%→90% with zero visible cue — reproduced in review). A `token_fields_corrupt` flag hides those three chips instead; genuinely-absent fields keep the longstanding behavior; numeric strings don't trip the gate (pinned).
- Setup budget-save failure no longer reports the unsaved budget in the completion summary; four stale 5s test timeouts → 15s (load-dependent flake, observed three of ten local runs).

## Review

Standard 4-agent review (no pre-code design round — pure renderer/UX additions over normalized fields, per the proportionality note in #113). All findings addressed: the float-floor, a null-theme-color crash (my own `_first()` convention violation), the corrupt-component gate, two vacuous negative tests, a CHANGELOG misattribution (v0.13's NameError was review-caught and never shipped — corrected), and the "always agree with the bar" overstatement under compaction thresholds.

**727 tests pass (+23)** across the usual matrix. Pure stdlib, zero dependencies. `context_tokens` and the coercion change the main statusline only for payloads that previously crashed it.