### PR TITLE
feat: repo-link footer at the end of --demo output (#116)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.14.1] - 2026-07-16
+
+### Added
+
+- **Repo-link footer at the end of `--demo` output** ([#116](https://github.com/mkalkere/claude-statusline/issues/116)) — `--demo` is the discovery funnel (the README's first CTA is `uvx claude-status --demo`, reaching people who haven't installed yet), and a repo link at the end of a demo is expected showcase content. Static line: no network, no state, no marker files. Statusline renders, `--install`, and `--print-config` are untouched.
+- **Design note for the record:** star-*detection* ("only ask if they haven't starred") was evaluated and rejected — it would require reading the user's GitHub identity (authenticated API or shelling into their `gh` CLI) and would be this package's first-ever network call, breaking the documented no-daemon/no-network/cannot-leak-data promise (AGENTS.md: "No daemon, no network, no background processes"). That promise outranks growth mechanics.
+
+### Notes
+
+- All remaining `timeout=10` subprocess tests aligned at 15s (same load-dependent flake class fixed for the 5s batch in v0.14.0 — one of the v0.13 e2e tests hit it under load during this release’s verification).
+- 728 tests pass (+1: the demo-footer pin alongside the existing demo assertions). Pure stdlib, zero dependencies, as always.
+
 ## [0.14.0] - 2026-07-16
 
 ### Added

--- a/claude_statusline/__init__.py
+++ b/claude_statusline/__init__.py
@@ -1,3 +1,3 @@
 """claude-status: Beautiful status line for Claude Code."""
 
-__version__ = "0.14.0"
+__version__ = "0.14.1"

--- a/claude_statusline/cli.py
+++ b/claude_statusline/cli.py
@@ -2465,6 +2465,16 @@ def cmd_demo():
         print("  all fields (vim + agent + worktree):")
         _print_indented(render(full_data, "default"))
         print()
+        # Repo-link footer (#116): --demo is the discovery funnel (the
+        # README's first CTA is `uvx claude-status --demo`, reaching
+        # people who haven't installed yet). A repo link at the end of
+        # a demo is expected showcase content. Static line — no
+        # network, no state, no marker files; star-DETECTION was
+        # evaluated and rejected (it would need the user's GitHub
+        # identity and would be this package's first network call,
+        # breaking the documented "no network" promise).
+        print("Repo & docs: https://github.com/mkalkere/claude-statusline"
+              " — a star helps others find it")
     finally:
         try:
             _self.get_session_tool_count = _orig_tool_count

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "claude-status"
-version = "0.14.0"
+version = "0.14.1"
 description = "Beautiful, informative status line for Claude Code — zero dependencies, cross-platform"
 readme = "README.md"
 license = {text = "MIT"}

--- a/tests/test_all.py
+++ b/tests/test_all.py
@@ -1887,7 +1887,7 @@ class TestCLISubprocess(unittest.TestCase):
     def _run(self, args, **kwargs):
         return subprocess.run(
             [sys.executable, "-m", "claude_statusline"] + args,
-            capture_output=True, timeout=10,
+            capture_output=True, timeout=15,
             env=self._env, encoding="utf-8", errors="replace", **kwargs,
         )
 
@@ -1911,6 +1911,11 @@ class TestCLISubprocess(unittest.TestCase):
         result = self._run([], input=data)
         self.assertEqual(result.returncode, 0)
         self.assertTrue(len(result.stdout.strip()) > 0)
+        # #116 acceptance pin: the demo's repo footer must never leak
+        # into statusline renders (it would appear in every Claude
+        # Code render and blow the line-fit budget). Symmetric with
+        # the star-ask absence pin on --install.
+        self.assertNotIn("github.com/mkalkere", result.stdout)
 
     def test_empty_stdin(self):
         result = self._run([], input="")
@@ -2534,7 +2539,7 @@ class TestSetupCommand(unittest.TestCase):
         """Demo should show all 7 themes."""
         result = subprocess.run(
             [sys.executable, "-m", "claude_statusline", "--demo"],
-            capture_output=True, timeout=10,
+            capture_output=True, timeout=15,
             encoding="utf-8", errors="replace",
             env={**os.environ, "PYTHONIOENCODING": "utf-8"},
         )
@@ -4736,11 +4741,26 @@ class TestSetupWizardUpdated(unittest.TestCase):
         )
         self.assertEqual(result.returncode, 0)
 
+    def test_demo_has_repo_footer(self):
+        """#116: the repo-link footer closes --demo output. Positive
+        control included so a demo crash can't pass vacuously."""
+        result = subprocess.run(
+            [sys.executable, "-m", "claude_statusline", "--demo"],
+            capture_output=True, timeout=15,
+            encoding="utf-8", errors="replace",
+            env={**os.environ, "PYTHONIOENCODING": "utf-8"},
+        )
+        self.assertEqual(result.returncode, 0)
+        self.assertIn("theme demos", result.stdout)
+        last_line = result.stdout.strip().split("\n")[-1]
+        self.assertIn("github.com/mkalkere/claude-statusline", last_line)
+        self.assertIn("a star helps", last_line)
+
     def test_demo_shows_all_themes(self):
         """Demo should show all 8 themes including focus."""
         result = subprocess.run(
             [sys.executable, "-m", "claude_statusline", "--demo"],
-            capture_output=True, timeout=10,
+            capture_output=True, timeout=15,
             encoding="utf-8", errors="replace",
             env={**os.environ, "PYTHONIOENCODING": "utf-8"},
         )
@@ -8863,7 +8883,7 @@ class TestSubagentEndToEnd(unittest.TestCase):
     def _run(self, args, payload):
         return subprocess.run(
             [sys.executable, "-m", "claude_statusline"] + args,
-            input=payload, capture_output=True, timeout=10,
+            input=payload, capture_output=True, timeout=15,
             env=self._env, encoding="utf-8", errors="replace",
             cwd=os.path.join(os.path.dirname(__file__), ".."),
         )


### PR DESCRIPTION
## Summary

One static line at the end of `--demo` output ([#116](https://github.com/mkalkere/claude-statusline/issues/116)):

```
Repo & docs: https://github.com/mkalkere/claude-statusline — a star helps others find it
```

`--demo` is the discovery funnel — the README's first CTA is `uvx claude-status --demo`, reaching prospective users before they install. **Star-detection was evaluated and rejected** (recorded in the CHANGELOG): it would require the user's GitHub identity and would be this package's first-ever network call, breaking the documented no-daemon/no-network promise.

## Review record (4 agents)

- code-reviewer: clean — em-dash-on-cp1252 verified safe empirically (`_force_utf8()` precedes all demo output; worst-case legacy-console simulation exits 0)
- silent-failure: sound — footer-skip-on-crash is correct ordering (no marketing after a traceback)
- test-analyzer: one gap — footer absence from statusline renders now pinned (`assertNotIn` in the stdin e2e, symmetric with the star-ask `--install` pin)
- comment-analyzer: one minor — a spliced paraphrase presented as a verbatim quote, corrected to cite AGENTS.md's actual phrase

Also: all remaining `timeout=10` subprocess tests aligned at 15s (same flake class as v0.14.0's 5s batch — a v0.13 e2e test hit it under load during verification, three-run clean since).

**728 tests pass (+1).** Pure stdlib, zero dependencies. Statusline renders, `--install`, and `--print-config` untouched (pinned).