### PR TITLE
test: close the remaining v0.15.0 review gaps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,7 +34,7 @@ Layout-correctness release, from a user report showing Line 2 cut mid-token (`ef
 - **Custom themes inherit** their base theme's `lineN` lists for any line they don't define themselves, so a custom theme that overrides only colors — or only one line — sees the same move. A custom theme that overrides *only* `line2`, copied from the pre-v0.15.0 default, would have paired its stale `line2` with the rebalanced `line1` and rendered `burn`/`rate_limits`/`context_size` twice; `render()` now enforces a **render-at-most-once invariant** across rows (first line wins), which also protects hand-written themes that list a section on two lines by mistake.
 - Theme screenshots in the README were regenerated for the new layout.
 - Dynamic overflow promotion (spilling Line 2 sections up when Line 1 has room) is deliberately **not** in this release — it is real new layout logic and is filed as [#121](https://github.com/mkalkere/claude-statusline/issues/121) for a design pass.
-- 746 tests pass (+18: a width-headroom sweep across seven terminal widths, a regression pin reproducing the reported session shape, the three-section promotion, a no-section-on-two-lines invariant across every theme, exact-composition pins for `minimal`/`focus`, and the model shortener's raw-vs-friendly guard). Pure stdlib, zero dependencies, as always.
+- 748 tests pass (+20: a width-headroom sweep across seven terminal widths, a regression pin reproducing the reported session shape, the three-section promotion, a no-section-on-two-lines invariant across every theme, exact-composition pins for `minimal`/`focus`, and the model shortener's raw-vs-friendly guard). Pure stdlib, zero dependencies, as always.
 
 ## [0.14.1] - 2026-07-16
 

--- a/tests/test_all.py
+++ b/tests/test_all.py
@@ -3236,6 +3236,28 @@ class TestThemeLineBalance(unittest.TestCase):
                 self.assertNotIn(section, THEMES[name]["line2"],
                                  "{}.line2".format(name))
 
+    def test_full_theme_compositions_are_pinned_exactly(self):
+        """minimal/focus had exact pins; the six FULL themes had only
+        membership checks, so an accidental reorder or a dropped
+        line-2 section would go unnoticed. Pin both lines exactly —
+        all six share one composition by design, and that sameness is
+        itself worth pinning."""
+        expected_line1 = ["bar", "tokens", "cache", "cost", "budget",
+                          "burn", "rate_limits", "context_size",
+                          "ctx_warning"]
+        expected_line2 = ["duration", "latency", "speed", "lines",
+                          "branch", "git_extras", "git_state",
+                          "commit_age", "tools", "sessions",
+                          "session_name", "vim", "agent", "worktree",
+                          "model", "output_style", "added_dirs",
+                          "git_worktree", "effort", "version",
+                          "cc_version", "clock"]
+        for name in self._FULL:
+            self.assertEqual(THEMES[name]["line1"], expected_line1,
+                             "{}.line1".format(name))
+            self.assertEqual(THEMES[name]["line2"], expected_line2,
+                             "{}.line2".format(name))
+
     def test_no_section_appears_on_two_lines(self):
         """A section on both lines would render twice — pin it for every
         theme, not just the rebalanced ones."""
@@ -5869,6 +5891,12 @@ class TestLine2FitsAt120Cols(unittest.TestCase):
         stage or re-raises _FULL_LAYOUT_MIN_COLS to 230 would silently
         lose this section, and the upper-bound width tests above would
         not notice (overflow tests pass either way).
+
+        NOTE (v0.15.0): `rate_limits` moved to line 1, so this no longer
+        exercises *line 2* recovery specifically — the drop/keep
+        property it pins is per-line and still real, but the sibling
+        assertion below on a still-line-2 section is what guards the
+        line-2 path now.
         """
         result = self._render_at_width(180)
         # Rate-limit indicators look like "5h:46%" / "7d:68%" in the
@@ -5881,6 +5909,20 @@ class TestLine2FitsAt120Cols(unittest.TestCase):
             "it should fit — precise stage may have over-dropped or "
             "been disabled."
         )
+
+    def test_line2_section_recovered_at_180_cols(self):
+        """Line-2 counterpart of the recovery pin above, re-anchored on
+        a section that is STILL on line 2 after the v0.15.0 rebalance
+        (`commit_age`). Without this, the recovery property for line 2
+        would be pinned by nothing."""
+        plain = re.sub(r"\x1b\[[0-9;]*m", "",
+                       self._render_at_width(180))
+        lines = plain.split("\n")
+        self.assertGreaterEqual(len(lines), 2, plain)
+        self.assertIn(
+            "last:", lines[1],
+            "commit_age was dropped from line 2 at 180 cols even though "
+            "it should fit — precise stage may have over-dropped.")
 
     def test_rate_limits_dropped_at_120_cols(self):
         """At 120 cols there is no room for rate_limits — the precise


### PR DESCRIPTION
Three review findings were left unaddressed when v0.15.0 shipped. Two are test-quality debt that release created; the third is filed rather than patched.

**Stale recovery pin.** `test_rate_limits_recovered_at_180_cols` documented itself as pinning *line 2* recovery, but v0.15.0 moved `rate_limits` to line 1 — so it kept passing while no longer testing what it claimed. Docstring corrected, plus a sibling test that re-anchors the line-2 recovery property on `commit_age` (still on line 2). Without it, line-2 recovery was pinned by nothing.

**Missing composition pins.** `minimal` and `focus` had exact composition pins; the six full themes had only membership checks, so an accidental reorder — or a dropped line-2 section — would go unnoticed. Both lines now pinned exactly for all six.

**Filed, not patched: [#123](https://github.com/mkalkere/claude-statusline/issues/123).** `_short_model` garbles version-dot joining when a non-numeric tail follows (`claude-opus-4-5-1m` → `Opus 4 5 1M`) and inverts legacy 3.x ids (`claude-3-5-sonnet-...` → `3 5 Sonnet`). Cosmetic, but v0.15.0 promoted this function from subagent rows onto the main line, so the blast radius grew. The modern and legacy id shapes want opposite parsing, so it needs a deliberate design pass rather than a regex tweak during cleanup.

748 tests pass.