### PR TITLE
docs: restore v0.15.0 test count to what the tag ships (746)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,7 +34,7 @@ Layout-correctness release, from a user report showing Line 2 cut mid-token (`ef
 - **Custom themes inherit** their base theme's `lineN` lists for any line they don't define themselves, so a custom theme that overrides only colors — or only one line — sees the same move. A custom theme that overrides *only* `line2`, copied from the pre-v0.15.0 default, would have paired its stale `line2` with the rebalanced `line1` and rendered `burn`/`rate_limits`/`context_size` twice; `render()` now enforces a **render-at-most-once invariant** across rows (first line wins), which also protects hand-written themes that list a section on two lines by mistake.
 - Theme screenshots in the README were regenerated for the new layout.
 - Dynamic overflow promotion (spilling Line 2 sections up when Line 1 has room) is deliberately **not** in this release — it is real new layout logic and is filed as [#121](https://github.com/mkalkere/claude-statusline/issues/121) for a design pass.
-- 748 tests pass (+20: a width-headroom sweep across seven terminal widths, a regression pin reproducing the reported session shape, the three-section promotion, a no-section-on-two-lines invariant across every theme, exact-composition pins for `minimal`/`focus`, and the model shortener's raw-vs-friendly guard). Pure stdlib, zero dependencies, as always.
+- 746 tests pass (+18: a width-headroom sweep across seven terminal widths, a regression pin reproducing the reported session shape, the three-section promotion, a no-section-on-two-lines invariant across every theme, exact-composition pins for `minimal`/`focus`, and the model shortener's raw-vs-friendly guard). Pure stdlib, zero dependencies, as always.
 
 ## [0.14.1] - 2026-07-16
 


### PR DESCRIPTION
A test-only follow-up (#124) bumped the count inside the already-released v0.15.0 entry to 748. The v0.15.0 tag ships **746** — anyone checking out that tag and running the suite would find the entry contradicting reality.

Released entries describe what shipped and stay frozen; later work gets its own entry rather than editing history. The two extra tests are post-release test-quality debt, already recorded in #124 and git history.